### PR TITLE
Remove resources from koin-android and koin-android-support

### DIFF
--- a/koin-android/koin-android-support/src/main/AndroidManifest.xml
+++ b/koin-android/koin-android-support/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.koin.android.support">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-    </application>
+    <application/>
 
 </manifest>

--- a/koin-android/koin-android-support/src/main/res/values/strings.xml
+++ b/koin-android/koin-android-support/src/main/res/values/strings.xml
@@ -1,4 +1,0 @@
-<resources>
-    <string name="app_name">koin-android-support</string>
-    <string name="url">this is a sample url string</string>
-</resources>

--- a/koin-android/koin-android/src/main/AndroidManifest.xml
+++ b/koin-android/koin-android/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.koin.android">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-    </application>
+    <application/>
 
 </manifest>

--- a/koin-android/koin-android/src/main/res/values/strings.xml
+++ b/koin-android/koin-android/src/main/res/values/strings.xml
@@ -1,4 +1,0 @@
-<resources>
-    <string name="app_name">koin-android</string>
-    <string name="url">this is a sample url string</string>
-</resources>


### PR DESCRIPTION
Resources like `app_name` are not needed and can conflict with app resources.