### PR TITLE
Fixed grammar and spelling mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,23 @@
 
 ### What's KOIN?
 
-Koin is a simple (but powerfull) Dependency injection framework for Android. It uses [Kotlin](https://kotlinlang.org/) and its functional power to get things done!  No proxy/CGLib, No code generation, No introspection. Just functional Kotlin and DSL magic ;)
+Koin is a simple (but powerful) dependency injection framework for Android. It uses [Kotlin](https://kotlinlang.org/) and its functional power to get things done!  No proxy/CGLib, no code generation, no introspection. Just functional Kotlin and DSL magic ;)
 
-KOIN is a very small library, that aims to be as simple as possible and let's write you dependency injection in a breath.
+KOIN is a very small library, that aims to be as simple as possible and let's you write dependency injection in a breath.
 
-*Just describe your stuffs and inject it!*
+*Just describe your stuff and inject it!*
 
 ### What's up?
 
 Check the latest changes in [What's New](https://github.com/Ekito/koin/wiki/What's-new-%3F) and the [Roadmap](https://github.com/Ekito/koin/wiki/Roadmap) for next releases.
 
-For users prior to Koin 0.4.x, please refer to [migrating to 0.4.0](https://github.com/Ekito/koin/wiki/Migrating#migrating-to-04x) page to understand the last changes. 
+For users using a version prior to Koin 0.4.x, please refer the [migrating to 0.4.0](https://github.com/Ekito/koin/wiki/Migrating#migrating-to-04x) page to understand the latest changes. 
 
 # Getting Started
 
 ## Gradle
 
-Check that you have `jcenter` repository. Add the following gradle dependency to your Android app:
+Check that you have the `jcenter` repository. Add the following gradle dependency to your Android app:
 
 ```gradle
 compile 'org.koin:koin-android:0.4.0'
@@ -26,7 +26,7 @@ compile 'org.koin:koin-android:0.4.0'
 
 ### Setup your Application
 
-To start Koin and your modules, you just have to make it in your Android *Application* class like below:
+To start Koin and your modules, you just have to implement it in your Android *Application* class like below:
 
 ```Kotlin
 class MainApplication : Application(), KoinContextAware {
@@ -43,7 +43,7 @@ class MainApplication : Application(), KoinContextAware {
 
 **Implement** `KoinContextAware` interface, and **override** your `koinContext` property with the `newKoinContext()` function builder.
 
-The `newKoinContext` function builder need a list of modules to run. A function can do it four you, like `allModules()` function.
+The `newKoinContext` function builder requires a list of modules to run. A function can do this for you, check out the `allModules()` function.
 
 # Dependency management
 
@@ -51,7 +51,7 @@ The `newKoinContext` function builder need a list of modules to run. A function 
 
 Koin ask you to declare your components in modules.
 
-A module class **extends** [AndroidModule](https://github.com/Ekito/koin/wiki#module-class) class and implement the `context()` function by using the `applicationContext` function builder, to declare a context like below:
+A module class **extends** [AndroidModule](https://github.com/Ekito/koin/wiki#module-class) class and implements the `context()` function by using the `applicationContext` function builder, to declare a context like below:
 
 ```Kotlin
 class WeatherModule : AndroidModule() {
@@ -75,7 +75,7 @@ class WeatherPresenter(val weatherRepository: WeatherRepository)
 class WeatherRepository(val weatherDatasource: WeatherDatasource)
 class LocalDataSource(val jsonReader: JsonReader) : WeatherDatasource
 ```
-Your module provides then an *applicationContext* (description of yoru components), which will be made of provided components and subcontexts.
+Your module then provides an *applicationContext* (description of yoru components), which will be made of provided components and subcontexts.
 
 You can refer to the [Koin DSL](https://github.com/Ekito/koin/wiki/Koin-DSL) for more details. 
 
@@ -84,7 +84,7 @@ You can refer to the [Koin DSL](https://github.com/Ekito/koin/wiki/Koin-DSL) for
 Once your app is configured, you have 2 ways of handling injection in your application:
 
 * In **Android components** (Activity,Fragment...): use the `by inject()` lazy operator
-* in **any Kotlin component**: injection is made by constructor
+* In **any Kotlin component**: injection is made by constructor
 
 
 Below a sample of injection with `by inject()` in an Android Activity:
@@ -112,7 +112,7 @@ The weather app [wiki page](https://github.com/Ekito/koin/wiki/The-Koin-Sample-A
 
 # Documentation
 
-A global [wiki](https://github.com/Ekito/koin/wiki) documentation page gather all features and references about Koin Framework.
+A global [wiki](https://github.com/Ekito/koin/wiki) documentation page gather all features and references about the Koin Framework.
 
 # Articles
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### What's KOIN?
 
-Koin is a simple (but powerful) dependency injection framework for Android. It uses [Kotlin](https://kotlinlang.org/) and its functional power to get things done!  No proxy/CGLib, no code generation, no introspection. Just functional Kotlin and DSL magic ;)
+KOIN is a simple (but powerful) dependency injection framework for Android. It uses [Kotlin](https://kotlinlang.org/) and its functional power to get things done!  No proxy/CGLib, no code generation, no introspection. Just functional Kotlin and DSL magic ;)
 
 KOIN is a very small library, that aims to be as simple as possible and let's you write dependency injection in a breath.
 
@@ -26,7 +26,7 @@ compile 'org.koin:koin-android:0.4.0'
 
 ### Setup your Application
 
-To start Koin and your modules, you just have to implement it in your Android *Application* class like below:
+To start KOIN and your modules, you just have to implement it in your Android *Application* class like below:
 
 ```Kotlin
 class MainApplication : Application(), KoinContextAware {
@@ -43,15 +43,15 @@ class MainApplication : Application(), KoinContextAware {
 
 **Implement** `KoinContextAware` interface, and **override** your `koinContext` property with the `newKoinContext()` function builder.
 
-The `newKoinContext` function builder requires a list of modules to run. A function can do this for you, check out the `allModules()` function.
+The `newKoinContext` function builder requires a list of modules to run. A function can manage this for you, check out the `allModules()` function.
 
 # Dependency management
 
 ## Describing your dependencies
 
-Koin ask you to declare your components in modules.
+KOIN requires you to declare your components in modules.
 
-A module class **extends** [AndroidModule](https://github.com/Ekito/koin/wiki#module-class) class and implements the `context()` function by using the `applicationContext` function builder, to declare a context like below:
+A module class **extends** your [AndroidModule](https://github.com/Ekito/koin/wiki#module-class) class and implements the `context()` function by using the `applicationContext` function builder, to declare a context like below:
 
 ```Kotlin
 class WeatherModule : AndroidModule() {
@@ -75,19 +75,19 @@ class WeatherPresenter(val weatherRepository: WeatherRepository)
 class WeatherRepository(val weatherDatasource: WeatherDatasource)
 class LocalDataSource(val jsonReader: JsonReader) : WeatherDatasource
 ```
-Your module then provides an *applicationContext* (description of yoru components), which will be made of provided components and subcontexts.
+Your module then provides an *applicationContext* (description of your components), which will be made of provided components and subcontexts.
 
-You can refer to the [Koin DSL](https://github.com/Ekito/koin/wiki/Koin-DSL) for more details. 
+You can refer to the [KOIN DSL](https://github.com/Ekito/koin/wiki/Koin-DSL) for more details. 
 
 ## Making dependency injection
 
 Once your app is configured, you have 2 ways of handling injection in your application:
 
-* In **Android components** (Activity,Fragment...): use the `by inject()` lazy operator
+* In **Android components** (Activity, Fragment etc.): use the `by inject()` lazy operator
 * In **any Kotlin component**: injection is made by constructor
 
 
-Below a sample of injection with `by inject()` in an Android Activity:
+Below is a sample of injection with `by inject()` in an Android Activity:
 
 ```Kotlin
 class WeatherActivity() : AppCompatActivity() {
@@ -100,7 +100,7 @@ class WeatherActivity() : AppCompatActivity() {
 
 ## Checking your modules
 
-Koin is an internal DSL: all your modules evolves directly with your code (if you change a component, it will also impact your modules). 
+KOIN is an internal DSL: all your modules evolves directly with your code (if you change a component, it will also impact your modules). 
 
 You can check your modules with `KoinContext.dryRun()` (launch all your modules and try to inject each component). Better is to place it in your tests folder and check it regulary - ensure everything is injected correctly.
 
@@ -108,11 +108,11 @@ You can check your modules with `KoinContext.dryRun()` (launch all your modules 
 
 The [*koin-sample-app*](https://github.com/Ekito/koin/tree/master/koin-android/koin-sample-app) application offers a complete application sample, with MVP Android style. 
 
-The weather app [wiki page](https://github.com/Ekito/koin/wiki/The-Koin-Sample-App) describes all about Koin features used.
+The weather app [wiki page](https://github.com/Ekito/koin/wiki/The-Koin-Sample-App) describes all the KOIN features used.
 
 # Documentation
 
-A global [wiki](https://github.com/Ekito/koin/wiki) documentation page gather all features and references about the Koin Framework.
+A global [wiki](https://github.com/Ekito/koin/wiki) documentation page gather all features and references about the KOIN Framework.
 
 # Articles
 


### PR DESCRIPTION
I fixed some grammar and spelling mistakes in the readme document. I also made the KOIN name (all in caps) more consistent.