### PR TITLE
Proper call for extension fun Application.startKoin

### DIFF
--- a/android/koin-android/src/main/java/org/koin/android/ext/android/AndroidExt.kt
+++ b/android/koin-android/src/main/java/org/koin/android/ext/android/AndroidExt.kt
@@ -15,10 +15,9 @@ private fun context() = (StandAloneContext.koinContext as KoinContext)
 
 /**
  * Create a new Koin Context
- * @param application - Android application
  * @param modules - list of AndroidModule
  */
-fun Application.startKoin(application: Application, modules: List<AndroidModule>, properties: Map<String, Any> = HashMap()) = StandAloneContext.startKoin(application, modules, properties)
+fun Application.startKoin(modules: List<AndroidModule>, properties: Map<String, Any> = HashMap()) = StandAloneContext.startKoin(this, modules, properties)
 
 /**
  * Bind an Android String to Koin property

--- a/samples/ktor-starter/src/main/kotlin/org/koin/sample/JobRoutes.kt
+++ b/samples/ktor-starter/src/main/kotlin/org/koin/sample/JobRoutes.kt
@@ -5,8 +5,8 @@ import io.ktor.application.call
 import io.ktor.response.respondText
 import io.ktor.routing.get
 import io.ktor.routing.routing
+import org.koin.ktor.ext.getProperty
 import org.koin.ktor.ext.inject
-import org.koin.ktor.ext.property
 import org.koin.ktor.ext.setProperty
 import org.koin.sample.BusinessServiceImpl.Companion.BYE_JOB
 import org.koin.sample.BusinessServiceImpl.Companion.HI_JOB
@@ -18,8 +18,8 @@ import org.koin.sample.KoinModule.Properties.MY_MODEL
  */
 fun Application.jobRoutes() {
 
-    // Inject service bean. Could alse be written : val service by inject<BusinessService>()
-    val service by inject<BusinessService>()
+    // Inject service bean. Could also be written : val service by inject<BusinessService>()
+    val service: BusinessService by inject()
 
     routing {
 
@@ -29,7 +29,7 @@ fun Application.jobRoutes() {
 
         get("/model") {
             // Inject lazily model object from properties
-            val model by property<Model>(MY_MODEL)
+            val model = getProperty<Model>(MY_MODEL)
             call.respondText("Model value = ${model.value}")
         }
 

--- a/samples/ktor-starter/src/test/kotlin/org/koin/sample/ApplicationJobRoutesTest.kt
+++ b/samples/ktor-starter/src/test/kotlin/org/koin/sample/ApplicationJobRoutesTest.kt
@@ -13,7 +13,7 @@ import org.koin.sample.KoinModule.Properties.BYE_MSG
 import org.koin.sample.KoinModule.Properties.HELLO_MSG
 import org.koin.sample.KoinModule.Properties.MY_MODEL
 import org.koin.standalone.StandAloneContext.startKoin
-import org.koin.standalone.property
+import org.koin.standalone.getProperty
 import org.koin.test.AbstractKoinTest
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -63,7 +63,7 @@ class ApplicationJobRoutesTest : AbstractKoinTest() {
 
         with(handleRequest(HttpMethod.Get, "/model")) {
             assertEquals(HttpStatusCode.OK, response.status())
-            val currentModel by property<Model>(MY_MODEL)
+            val currentModel = getProperty<Model>(MY_MODEL)
 
             assertEquals("Test value", currentModel.value)
             assertEquals("Model value = ${currentModel.value}", response.content)
@@ -76,7 +76,7 @@ class ApplicationJobRoutesTest : AbstractKoinTest() {
 
         with(handleRequest(HttpMethod.Get, "/model")) {
             assertEquals(HttpStatusCode.OK, response.status())
-            val currentModel by property<Model>(MY_MODEL)
+            val currentModel = getProperty<Model>(MY_MODEL)
 
             assertEquals("Hi already said !", currentModel.value)
             assertEquals("Model value = ${currentModel.value}", response.content)


### PR DESCRIPTION
Double pass of Application reference. From Java code this method looks ugly:
AndroidExtKt.startKoin(this, this, modules, properties);

Of course this fix will brake existing samples