### PR TITLE
Android Arch Lifecycle management of Koin Context.

### DIFF
--- a/android/koin-android/build.gradle
+++ b/android/koin-android/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
@@ -36,6 +37,9 @@ dependencies {
     })
     // Kotlin
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    // Android Lifecycles
+    compile "android.arch.lifecycle:runtime:$android_arch_lifecycle_version"
+    kapt "android.arch.lifecycle:compiler:$android_arch_lifecycle_compiler_version"
     // Koin
     compile "org.koin:koin-core:$koin_version"
     testCompile "org.koin:koin-test:$koin_version"

--- a/android/koin-android/src/main/java/org/koin/android/lifecycle/Context.kt
+++ b/android/koin-android/src/main/java/org/koin/android/lifecycle/Context.kt
@@ -1,0 +1,57 @@
+package org.koin.android.lifecycle
+
+import android.arch.lifecycle.Lifecycle
+import android.arch.lifecycle.LifecycleObserver
+import android.arch.lifecycle.OnLifecycleEvent
+import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentActivity
+import org.koin.standalone.KoinComponent
+import org.koin.standalone.releaseContext
+
+sealed class LifecycleEvent {
+    object OnDestroy : LifecycleEvent()
+    object OnStop : LifecycleEvent()
+    object OnPause : LifecycleEvent()
+}
+
+fun FragmentActivity.manageContext(
+        contextName: String,
+        releaseEvent: LifecycleEvent = LifecycleEvent.OnDestroy
+): LifecycleObserver = LifecycleContextBinder(contextName, releaseEvent, lifecycle)
+
+fun Fragment.manageContext(
+        contextName: String,
+        releaseEvent: LifecycleEvent = LifecycleEvent.OnDestroy
+): LifecycleObserver = LifecycleContextBinder(contextName, releaseEvent, lifecycle)
+
+private class LifecycleContextBinder(
+        private val contextName: String,
+        private val boundEvent: LifecycleEvent,
+        lifecycle: Lifecycle
+) : LifecycleObserver, KoinComponent {
+    init {
+        lifecycle.addObserver(this)
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    fun destroy() {
+        when (boundEvent) {
+            LifecycleEvent.OnDestroy -> releaseContext(contextName)
+        }
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+    fun stop() {
+        when (boundEvent) {
+            LifecycleEvent.OnStop -> releaseContext(contextName)
+        }
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+    fun pause() {
+        when (boundEvent) {
+            LifecycleEvent.OnPause -> releaseContext(contextName)
+        }
+    }
+}
+

--- a/common-android.gradle
+++ b/common-android.gradle
@@ -9,4 +9,8 @@ ext {
     buildToolsVersion = '26.0.2'
 
     supportLibraryVersion = '26.0.2'
+
+    // Android Architecture
+    android_arch_lifecycle_version = '1.0.3'
+    android_arch_lifecycler_compiler_version = '1.0.0'
 }


### PR DESCRIPTION
A lifecycle observer that can release the Koin Context and a couple of extension functions to make it easier to use.

----

I thought I'd just quickly crib this together from one of my projects and push it out here, in case it is useful for you or anybody following the project. The idea is to use the new Android Lifecycle Components to release the Koin context, retaining the flexibility of the existing approach. The only trouble is that it adds further dependencies to the project plus the use of the annotations processor. 

Usage
```kotlin
class MainActivity : FragmentActivity() {
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)


        manageContext("MainActivityContext")


    }
}
```

`manageContext` can be called with an optional parameter to set which lifecycle event releases the context.

Please feel free to let me know what you think.