### PR TITLE
Take bean name into account when checking for cycles

### DIFF
--- a/koin-core/src/main/kotlin/org/koin/core/bean/BeanDefinition.kt
+++ b/koin-core/src/main/kotlin/org/koin/core/bean/BeanDefinition.kt
@@ -55,10 +55,6 @@ data class BeanDefinition<out T>(val name: String = "", val clazz: KClass<*>, va
     override fun hashCode(): Int {
         return name.hashCode() + clazz.hashCode() + scope.hashCode()
     }
-
-    fun isCompatibleWith(clazz: KClass<*>): Boolean {
-        return this.clazz == clazz || types.contains(clazz)
-    }
 }
 
 typealias Definition<T> = (ParametersProvider) -> T

--- a/koin-core/src/main/kotlin/org/koin/core/instance/InstanceFactory.kt
+++ b/koin-core/src/main/kotlin/org/koin/core/instance/InstanceFactory.kt
@@ -59,6 +59,7 @@ class InstanceFactory() {
             instance as T
             return instance
         } catch (e: Throwable) {
+            e.printStackTrace()
             throw BeanInstanceCreationException("Can't create bean $def due to error :\n\t$e")
         }
     }


### PR DESCRIPTION
Solves #75 

`KoinContext#resolveInstance` now takes into account bean names when beans are being resolved by name. This allows instances of the same type to be injected to one another, so long as they have unique names. Cycles are still prevented by climbing up the resolution stack, as before, it just takes into account the name.

This PR also prints out the stacktrace of the exception that prevents the instance creation.

This is helpful to users trying to debug what is preventing their Koin implementation from working, otherwise the entire stacktrace is swallowed and we only get the exception type.