### PR TITLE
Decreased nesting levels

### DIFF
--- a/koin-core/src/main/kotlin/org/koin/KoinContext.kt
+++ b/koin-core/src/main/kotlin/org/koin/KoinContext.kt
@@ -112,18 +112,19 @@ class KoinContext(
             filteredByVisibility
         } else definitionResolver()).distinct()
 
-        return if (candidates.size == 1) {
-            candidates.first()
-        } else {
-            when {
-                candidates.isEmpty() -> throw NoBeanDefFoundException("No definition found to resolve type '$clazzName'. Check your module definition")
-                else -> throw DependencyResolutionException(
-                    "Multiple definitions found to resolve type '$clazzName' - Koin can't choose between :\n\t${candidates.joinToString(
-                        "\n\t"
-                    )}\n\tCheck your modules definition or use name attribute to resolve components."
-                )
-            }
+        if (candidates.size == 1) {
+            return candidates.first()
         }
+
+        if (candidates.isEmpty())
+            throw NoBeanDefFoundException("No definition found to resolve type '$clazzName'. Check your module definition")
+
+        throw DependencyResolutionException(
+            "Multiple definitions found to resolve type '$clazzName' - Koin can't choose between :\n\t${candidates.joinToString(
+                "\n\t"
+            )}\n\tCheck your modules definition or use name attribute to resolve components."
+        )
+
     }
 
     /**


### PR DESCRIPTION
... by leveraging natural flow interruption already provided by `return` and `throw` statements.

Having less nesting and interrupting flow early on usually makes the code easier to read.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ekito/koin/85)
<!-- Reviewable:end -->
