### PR TITLE
Minor cleanup

### DIFF
--- a/koin-core/src/main/kotlin/org/koin/Koin.kt
+++ b/koin-core/src/main/kotlin/org/koin/Koin.kt
@@ -50,9 +50,9 @@ class Koin(val koinContext: KoinContext) {
     }
 
     /**
-     * load given list of module instances into current StandAlone koin context
+     * load given collection of module instances into current koin context
      */
-    fun build(modules: List<Module>): Koin {
+    fun build(modules: Collection<Module>): Koin {
         modules.forEach { module ->
             registerDefinitions(module())
         }


### PR DESCRIPTION
Change #1: List -> Collection
I don't think order matters and using collection allows people to pass both `Sets` and `Lists`

Change #2: kotlindoc
The method isn't limited to StandaloneContext so I reworded the comment