### PR TITLE
Add explicit bean override functionality

### DIFF
--- a/koin-android-architecture/src/main/java/org/koin/android/architecture/ext/KoinExt.kt
+++ b/koin-android-architecture/src/main/java/org/koin/android/architecture/ext/KoinExt.kt
@@ -17,9 +17,10 @@ import org.koin.standalone.StandAloneContext
  */
 inline fun <reified T : ViewModel> Context.viewModel(
     name: String = "",
+    override: Boolean = false,
     noinline definition: Definition<T>
 ) {
-    val bean = factory(name, definition)
+    val bean = factory(name, override, definition)
     bean.bind(ViewModel::class)
 }
 

--- a/koin-core/src/main/kotlin/org/koin/core/bean/BeanDefinition.kt
+++ b/koin-core/src/main/kotlin/org/koin/core/bean/BeanDefinition.kt
@@ -26,6 +26,7 @@ data class BeanDefinition<out T>(
     var types: List<KClass<*>> = arrayListOf(),
     val scope: Scope = Scope.root(),
     val isSingleton: Boolean = true,
+    val override: Boolean = false,
     val definition: Definition<T>
 ) {
 
@@ -42,7 +43,7 @@ data class BeanDefinition<out T>(
      */
     fun isNotASingleton() = !isSingleton
 
-    private fun boundTypes(): String = "(" + types.map { it.java.canonicalName }.joinToString() + ")"
+    private fun boundTypes(): String = "(" + types.joinToString { it.java.canonicalName } + ")"
 
     override fun toString(): String {
         val n = if (name.isBlank()) "" else "name='$name', "
@@ -50,7 +51,8 @@ data class BeanDefinition<out T>(
         val s = if (isSingleton) "Bean" else "Factory"
         val b = if (types.isEmpty()) "" else ", binds~${boundTypes()}"
         val sn = if (scope != Scope.root()) ", scope:${scope.name}" else ""
-        return "$s[$n$c$b$sn]"
+        val o = ", override=$override"
+        return "$s[$n$c$b$sn$o]"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/koin-core/src/main/kotlin/org/koin/dsl/context/Context.kt
+++ b/koin-core/src/main/kotlin/org/koin/dsl/context/Context.kt
@@ -12,7 +12,7 @@ import org.koin.core.scope.Scope
  *
  * @author - Arnaud GIULIANI
  */
-class Context(val name: String = Scope.ROOT, val koinContext: KoinContext) {
+class Context(val name: String = Scope.ROOT, val koinContext: KoinContext, val override: Boolean) {
 
     /**
      * bean definitions
@@ -27,9 +27,10 @@ class Context(val name: String = Scope.ROOT, val koinContext: KoinContext) {
     /**
      * Create a sub context in actual context
      * @param name
+     * @param override
      */
-    fun context(name: String, init: Context.() -> Unit): Context {
-        val newContext = Context(name, koinContext)
+    fun context(name: String, override: Boolean? = null, init: Context.() -> Unit): Context {
+        val newContext = Context(name, koinContext, override ?: this@Context.override)
         subContexts += newContext
         return newContext.apply(init)
     }
@@ -43,9 +44,14 @@ class Context(val name: String = Scope.ROOT, val koinContext: KoinContext) {
     inline fun <reified T : Any> provide(
         name: String = "",
         isSingleton: Boolean = true,
+        override: Boolean? = null,
         noinline definition: Definition<T>
     ): BeanDefinition<T> {
-        val beanDefinition = BeanDefinition(name, T::class, isSingleton = isSingleton, definition = definition)
+        val beanDefinition = BeanDefinition(
+            name, T::class,
+            isSingleton = isSingleton,
+            override = override ?: this@Context.override,
+            definition = definition)
         definitions += beanDefinition
         return beanDefinition
     }
@@ -54,8 +60,8 @@ class Context(val name: String = Scope.ROOT, val koinContext: KoinContext) {
      * Provide a bean definition - alias to provide
      * @param name
      */
-    inline fun <reified T : Any> bean(name: String = "", noinline definition: Definition<T>): BeanDefinition<T> {
-        return provide(name, true, definition)
+    inline fun <reified T : Any> bean(name: String = "", override: Boolean? = null, noinline definition: Definition<T>): BeanDefinition<T> {
+        return provide(name, true, override, definition)
     }
 
     /**
@@ -64,8 +70,8 @@ class Context(val name: String = Scope.ROOT, val koinContext: KoinContext) {
      *
      * @param name
      */
-    inline fun <reified T : Any> factory(name: String = "", noinline definition: Definition<T>): BeanDefinition<T> {
-        return provide(name, false, definition)
+    inline fun <reified T : Any> factory(name: String = "", override: Boolean? = null, noinline definition: Definition<T>): BeanDefinition<T> {
+        return provide(name, false, override, definition)
     }
 
     /**

--- a/koin-core/src/main/kotlin/org/koin/dsl/module/Module.kt
+++ b/koin-core/src/main/kotlin/org/koin/dsl/module/Module.kt
@@ -9,7 +9,8 @@ import org.koin.standalone.StandAloneContext
 /**
  * Create Context
  */
-fun applicationContext(init: Context.() -> Unit): Module = { Context(Scope.ROOT, StandAloneContext.koinContext as KoinContext).apply(init) }
+fun applicationContext(override: Boolean = false,
+                       init: Context.() -> Unit): Module = { Context(Scope.ROOT, StandAloneContext.koinContext as KoinContext, override).apply(init) }
 
 /**
  * Module - function that gives a module

--- a/koin-core/src/main/kotlin/org/koin/error/BeanOverrideException.kt
+++ b/koin-core/src/main/kotlin/org/koin/error/BeanOverrideException.kt
@@ -1,0 +1,3 @@
+package org.koin.error
+
+class BeanOverrideException(msg: String) : Exception(msg)

--- a/koin-spark/src/main/kotlin/org/koin/spark/KoinExt.kt
+++ b/koin-spark/src/main/kotlin/org/koin/spark/KoinExt.kt
@@ -9,8 +9,8 @@ import org.koin.dsl.context.ParameterHolder
 /**
  * Declare a Spark controller
  */
-inline fun <reified T : Any> Context.controller(name: String = "", noinline definition: Definition<T>) {
-    val def = bean(name, definition)
+inline fun <reified T : Any> Context.controller(name: String = "", override: Boolean = false, noinline definition: Definition<T>) {
+    val def = bean(name, override, definition)
     def.bind(SparkController::class)
 }
 

--- a/koin-test/src/test/kotlin/org/koin/test/core/GenericBindingTest.kt
+++ b/koin-test/src/test/kotlin/org/koin/test/core/GenericBindingTest.kt
@@ -11,13 +11,13 @@ import org.koin.test.AutoCloseKoinTest
 
 class GenericBindingTest : AutoCloseKoinTest() {
 
-    val module = applicationContext {
+    val module = applicationContext(override = true) {
         bean("a") { ComponentA() as InterfaceComponent<String> }
         bean("b") { ComponentB() as InterfaceComponent<Int> }
 
     }
 
-    val badModule = applicationContext {
+    val badModule = applicationContext(override = true) {
         bean { ComponentA() as InterfaceComponent<String> }
         bean { ComponentB() as InterfaceComponent<Int> }
 

--- a/koin-test/src/test/kotlin/org/koin/test/core/OverrideTest.kt
+++ b/koin-test/src/test/kotlin/org/koin/test/core/OverrideTest.kt
@@ -1,32 +1,59 @@
 package org.koin.test.core
 
 import org.junit.Assert.*
+import org.junit.Ignore
 import org.junit.Test
 import org.koin.dsl.module.applicationContext
+import org.koin.error.BeanOverrideException
+import org.koin.standalone.StandAloneContext.loadKoinModules
 import org.koin.standalone.StandAloneContext.startKoin
 import org.koin.standalone.get
+import org.koin.standalone.releaseContext
 import org.koin.test.AutoCloseKoinTest
 
 class OverrideTest : AutoCloseKoinTest() {
 
-    val sampleModule1 = applicationContext {
+    val sampleModule1 = applicationContext(override = true) {
         bean { ComponentA() } bind MyInterface::class
         bean { ComponentA() }
     }
 
-    val sampleModule2 = applicationContext {
+    val sampleModule2 = applicationContext(override = true) {
         bean("A") { ComponentA() as MyInterface }
         bean("B") { ComponentB() as MyInterface }
     }
 
-    val sampleModule3 = applicationContext {
+    val sampleModule3 = applicationContext(override = true) {
         bean { ComponentB() as MyInterface }
         bean { ComponentA() as MyInterface }
     }
 
-    val sampleModule4 = applicationContext {
+    val sampleModule4 = applicationContext(override = true) {
         bean { ComponentB() as MyInterface }
         factory { ComponentA() as MyInterface }
+    }
+
+    val noOverrideModule = applicationContext {
+        bean { ComponentA() as MyInterface }
+        bean { ComponentB() as MyInterface }
+    }
+
+    val overrideOnBeanDefinitionModule = applicationContext {
+        bean { ComponentA() as MyInterface }
+        bean(override = true) { ComponentB() as MyInterface }
+    }
+
+    val overrideOnSubContextModule = applicationContext {
+        context(name = "SUBCONTEXT", override = true) {
+            bean { ComponentA() as MyInterface }
+            bean { ComponentB() as MyInterface }
+        }
+    }
+
+    val noOverrideWithSubContextModule = applicationContext {
+        context(name = "SUBCONTEXT") {
+            bean { ComponentA() as MyInterface }
+        }
     }
 
     class ComponentA : MyInterface
@@ -71,5 +98,56 @@ class OverrideTest : AutoCloseKoinTest() {
         assertNotNull(intf)
         assertTrue(intf is ComponentA)
         assertNotEquals(intf, get<MyInterface>())
+    }
+
+    @Test
+    fun `override without override flag`() {
+        try {
+            startKoin(listOf(noOverrideModule))
+            fail("Should throw BeanOverrideException")
+        } catch (e: BeanOverrideException) {
+        }
+    }
+
+    @Test
+    fun `override on bean definition`() {
+        startKoin(listOf(overrideOnBeanDefinitionModule))
+
+        val intf = get<MyInterface>()
+        assertNotNull(intf)
+        assertTrue(intf is ComponentB)
+    }
+
+    @Test
+    fun `override on sub context`() {
+        startKoin(listOf(overrideOnSubContextModule))
+
+        val intf = get<MyInterface>()
+        assertNotNull(intf)
+        assertTrue(intf is ComponentB)
+    }
+
+    @Test
+    @Ignore
+    fun `no override with sub context`() {
+        startKoin(listOf(noOverrideWithSubContextModule))
+
+        val intf = get<MyInterface>()
+        assertNotNull(intf)
+        assertTrue(intf is ComponentA)
+
+        try {
+            loadKoinModules(noOverrideWithSubContextModule)
+            fail("Should throw BeanOverrideException")
+        } catch (e: BeanOverrideException) {
+        }
+
+        releaseContext("SUBCONTEXT")
+
+        try {
+            loadKoinModules(noOverrideWithSubContextModule)
+        } catch (e: BeanOverrideException) {
+            fail("Should NOT throw BeanOverrideException because context was released")
+        }
     }
 }

--- a/koin-test/src/test/kotlin/org/koin/test/core/RunModulesTest.kt
+++ b/koin-test/src/test/kotlin/org/koin/test/core/RunModulesTest.kt
@@ -22,12 +22,12 @@ class RunModulesTest : AutoCloseKoinTest() {
         bean { ComponentB(get()) }
     }
 
-    val moduleC = applicationContext {
+    val moduleC = applicationContext(override = true) {
         bean { ComponentA("A2") }
     }
 
     val moduleD = applicationContext {
-        context("D") {
+        context("D", override = true) {
             bean { ComponentA("D") }
         }
     }


### PR DESCRIPTION
I had the following code

```kotlin
import org.koin.dsl.module.applicationContext
import org.koin.standalone.KoinComponent
import org.koin.standalone.StandAloneContext.startKoin
import org.koin.standalone.inject

typealias StringProvider = () -> String
typealias IntProvider = () -> Int

class Example(private val stringProvider: StringProvider,
              private val intProvider: IntProvider) {

    fun run() {
        // Output is:
        //   1337
        //   1337
        // Output should be:
        //   Hello world
        //   1337
        println(stringProvider())
        println(intProvider())
    }
}

object Main : KoinComponent {

    private val example: Example by inject()

    fun run() {
        example.run()
    }
}

fun createModule(stringProvider: StringProvider,
                 intProvider: IntProvider) = applicationContext {

    factory { stringProvider }

    factory { intProvider }

    factory { Example(get(), get()) }
}

fun main(args: Array<String>) {
    startKoin(listOf(createModule(stringProvider = { "Hello world" },
                                  intProvider = { 1337 })))
    Main.run()
}
```

and first was wondering why the output is

```
1337
1337
```

instead of

```
Hello world
1337
```

Since the function types in this example resolve to `kotlin.jvm.functions.Function0<R>` and the generic type is lost during runtime due to JVM's type erasure I'm aware that the solution to this problem is

```kotlin
factory("stringProvider") { stringProvider }

factory("intProvider") { intProvider }

factory { Example(get("stringProvider"), get("intProvider")) }
```

However before the first factory was "silently" overridden by the second factory because both resolve to `Function0` (yes I know, the override is logged to console).

I suggest that Koin should have an option ("strict mode"?) that turns overrides into runtime exceptions so that all types must be either unique or have names. This should help in reducing unexpected behaviour.