### PR TITLE
[Maintenance] Cleanup of examples

### DIFF
--- a/examples/android-perfs/build.gradle
+++ b/examples/android-perfs/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
@@ -25,8 +27,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_1_8
+        }
     }
 }
 
@@ -37,7 +41,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation project(":jvm-perfs")
 
-    testImplementation "junit:junit:4.13.2"
+    testImplementation "junit:junit:$junit_version"
     // bench
     testImplementation "org.openjdk.jmh:jmh-core:1.36"
     testImplementation "org.openjdk.jmh:jmh-generator-annprocess:1.36"

--- a/examples/android-perfs/build.gradle
+++ b/examples/android-perfs/build.gradle
@@ -21,12 +21,12 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
 

--- a/examples/android-perfs/src/main/java/org/koin/sample/android/main/MainActivity.kt
+++ b/examples/android-perfs/src/main/java/org/koin/sample/android/main/MainActivity.kt
@@ -3,7 +3,11 @@ package org.koin.sample.android.main
 import android.os.Bundle
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.coroutines.*
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import org.koin.sample.android.R
 import org.koin.sample.android.main.MainApplication.Companion.limits
 import org.koin.sample.android.main.MainApplication.Companion.results
@@ -17,7 +21,6 @@ class MainActivity : AppCompatActivity(), CoroutineScope {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.main_activity)
         title = "Android First Perfs"
-
     }
 
     override fun onStart() {
@@ -41,11 +44,13 @@ class MainActivity : AppCompatActivity(), CoroutineScope {
 
         textWidget.text = textReport
 
-        val color = if (!ok) {
+        val color = if (ok) {
+            android.R.color.holo_green_dark
+        } else {
             android.R.color.holo_red_dark
-        } else android.R.color.holo_green_dark
+        }
 
-        textWidget.setTextColor(resources.getColor(color))
+        textWidget.setTextColor(ContextCompat.getColor(this, color))
     }
 
     override fun onDestroy() {

--- a/examples/androidx-samples/build.gradle
+++ b/examples/androidx-samples/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 buildscript {
     repositories {
         mavenLocal()
@@ -46,8 +48,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_1_8
+        }
     }
 }
 
@@ -57,7 +61,7 @@ dependencies {
     implementation "androidx.work:work-runtime-ktx:2.10.5"
     implementation 'com.squareup.leakcanary:leakcanary-android:2.14'
     testImplementation 'androidx.arch.core:core-testing:2.2.0'
-    testImplementation "junit:junit:4.13.2"
+    testImplementation "junit:junit:$junit_version"
 
     // Koin
     implementation platform("io.insert-koin:koin-bom:$koin_android_version")

--- a/examples/androidx-samples/build.gradle
+++ b/examples/androidx-samples/build.gradle
@@ -26,10 +26,6 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
-
     buildTypes {
         release {
             minifyEnabled false
@@ -46,12 +42,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
 

--- a/examples/androidx-samples/src/test/java/CheckModulesTest.kt
+++ b/examples/androidx-samples/src/test/java/CheckModulesTest.kt
@@ -1,12 +1,14 @@
 import org.junit.Test
 import org.koin.android.test.verify.AndroidVerify.androidTypes
-import org.koin.sample.sandbox.di.appModules
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.sample.sandbox.di.mainModules
 import org.koin.test.verify.verify
 
 class CheckModulesTest {
 
+    @OptIn(KoinExperimentalAPI::class)
     @Test
     fun `Verify Module Configuration`() {
-        appModules.verify(extraTypes = androidTypes)
+        mainModules.value.verify(extraTypes = androidTypes)
     }
 }

--- a/examples/coffee-maker/build.gradle
+++ b/examples/coffee-maker/build.gradle
@@ -16,7 +16,6 @@ archivesBaseName = 'example-coffee-maker'
 dependencies {
     implementation "io.insert-koin:koin-core:$koin_version"
 
-    testImplementation "junit:junit:4.13.2"
     testImplementation "io.insert-koin:koin-test:$koin_version"
     testImplementation "io.insert-koin:koin-test-junit4:$koin_version"
     testImplementation "junit:junit:$junit_version"

--- a/examples/gradle/versions.gradle
+++ b/examples/gradle/versions.gradle
@@ -12,8 +12,6 @@ ext {
 
     // Test
     junit_version = "4.13.2"
-    junit5_version = "5.11.2"
-    mockito_version = "5.2.0"
     mockk_version = "1.12.2"
 
     // build Tools

--- a/examples/gradle/versions.gradle
+++ b/examples/gradle/versions.gradle
@@ -7,7 +7,7 @@ ext {
     koin_compose_version = koin_version
 
     coroutines_version = "1.10.2"
-    ktor_version = "3.3.1"//"3.2.0-eap-1310"
+    ktor_version = "3.3.1"
     jb_compose_version = "1.9.1"
 
     // Test

--- a/examples/jvm-perfs/build.gradle.kts
+++ b/examples/jvm-perfs/build.gradle.kts
@@ -1,32 +1,34 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 repositories.mavenCentral()
+
+apply(from = "../gradle/versions.gradle")
 
 plugins {
     id("org.jetbrains.kotlin.jvm")
     kotlin("kapt")
 }
 
-val jvmTarget = "17"
-
-tasks.getByName<JavaCompile>("compileJava") {
-    targetCompatibility = jvmTarget
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
 }
 
-tasks.getByName<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>("compileKotlin") {
+tasks.withType<KotlinJvmCompile>().configureEach {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 
 val jmhVersion = "1.36"
-//TODO get from existing version.gradle file
-val koin_version = "4.0.0"
+val koinVersion = extra["koin_version"] as String
 
 dependencies {
-    api("io.insert-koin:koin-core:$koin_version")
-    api("io.insert-koin:koin-core-coroutines:$koin_version")
-    api("io.insert-koin:koin-fu:$koin_version")
+    api("io.insert-koin:koin-core:$koinVersion")
+    api("io.insert-koin:koin-core-coroutines:$koinVersion")
+    api("io.insert-koin:koin-fu:$koinVersion")
     implementation("org.openjdk.jmh:jmh-core:$jmhVersion")
     kapt("org.openjdk.jmh:jmh-generator-annprocess:$jmhVersion")
 }

--- a/examples/jvm-perfs/src/main/kotlin/org/koin/benchmark/BenchmarkClass.kt
+++ b/examples/jvm-perfs/src/main/kotlin/org/koin/benchmark/BenchmarkClass.kt
@@ -1,6 +1,7 @@
 package org.koin.benchmark
 
 import org.koin.benchmark.PerfRunner.koinScenario
+import org.koin.core.annotation.KoinInternalApi
 import org.koin.dsl.koinApplication
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
@@ -57,6 +58,7 @@ open class BenchmarkClass {
         koinScenario(koin)
     }
 
+    @OptIn(KoinInternalApi::class)
     @Benchmark
     fun flattenRecursive(state: BenchmarkState) {
         org.koin.core.module.flatten(state.nestedModules)

--- a/examples/multimodule-ktor/app/build.gradle
+++ b/examples/multimodule-ktor/app/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
     testImplementation "io.insert-koin:koin-test:$koin_version"
     testImplementation "io.insert-koin:koin-test-junit4:$koin_version"
-    testImplementation "junit:junit:4.13.2"
+    testImplementation "junit:junit:$junit_version"
 
     testImplementation "io.ktor:ktor-server-test-host:$ktor_version"
 }

--- a/examples/multimodule-ktor/common/build.gradle
+++ b/examples/multimodule-ktor/common/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     testImplementation "io.insert-koin:koin-test:$koin_version"
     testImplementation "io.insert-koin:koin-test-junit4:$koin_version"
-    testImplementation "junit:junit:4.13.2"
+    testImplementation "junit:junit:$junit_version"
 
     // Ktor
     testImplementation "io.ktor:ktor-server-test-host:1.6.7"

--- a/examples/sample-android-compose/build.gradle
+++ b/examples/sample-android-compose/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
@@ -30,8 +32,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_1_8
+        }
     }
 
     buildFeatures {
@@ -57,5 +61,5 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling-preview:1.9.4"
     implementation 'androidx.appcompat:appcompat:1.7.1'
 
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation "junit:junit:$junit_version"
 }

--- a/examples/sample-android-compose/build.gradle
+++ b/examples/sample-android-compose/build.gradle
@@ -26,12 +26,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 
     buildFeatures {


### PR DESCRIPTION
- fixed `koin_version`;
- `compileOptions` fixed;
- `jvmTarget` taken from `JavaVersion`;
- warning for `resources.getColor` fixed;
- `examples.jvm-prefs` fixed and added `koin_version` from versions file;
- usage of `flatten` marked as internal fixed.