### PR TITLE
Fix Never Succeeding Cast in koinActivityViewModel

### DIFF
--- a/projects/compose/koin-compose-viewmodel/src/androidMain/kotlin/org/koin/compose/viewmodel/ViewModelExt.kt
+++ b/projects/compose/koin-compose-viewmodel/src/androidMain/kotlin/org/koin/compose/viewmodel/ViewModelExt.kt
@@ -41,7 +41,7 @@ inline fun <reified T : ViewModel> koinActivityViewModel(
     noinline parameters: ParametersDefinition? = null,
 ): T = koinViewModel<T>(
     qualifier = qualifier,
-    viewModelStoreOwner = LocalActivity as ComponentActivity,
+    viewModelStoreOwner = LocalActivity.current as ComponentActivity,
     key = key,
     scope = scope,
     parameters = parameters,


### PR DESCRIPTION
Fixed the Cast as described in title:
`
 java.lang.ClassCastException: androidx.compose.runtime.ComputedProvidableCompositionLocal cannot be cast to androidx.activity.ComponentActivity`