### PR TITLE
refactor(androidx): standardize Koin startup package naming

### DIFF
--- a/projects/android/koin-androidx-startup/api/koin-androidx-startup.api
+++ b/projects/android/koin-androidx-startup/api/koin-androidx-startup.api
@@ -1,11 +1,11 @@
-public final class org/koin/androix/startup/KoinInitializer : androidx/startup/Initializer {
+public final class org/koin/androidx/startup/KoinInitializer : androidx/startup/Initializer {
 	public fun <init> ()V
 	public synthetic fun create (Landroid/content/Context;)Ljava/lang/Object;
 	public fun create (Landroid/content/Context;)Lorg/koin/core/Koin;
 	public fun dependencies ()Ljava/util/List;
 }
 
-public abstract interface class org/koin/androix/startup/KoinStartup {
+public abstract interface class org/koin/androidx/startup/KoinStartup {
 	public abstract fun onKoinStartup ()Lorg/koin/dsl/KoinConfiguration;
 }
 

--- a/projects/android/koin-androidx-startup/src/main/AndroidManifest.xml
+++ b/projects/android/koin-androidx-startup/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
             tools:node="merge">
             <!-- This entry makes ExampleLoggerInitializer discoverable. -->
             <meta-data
-                android:name="org.koin.androix.startup.KoinInitializer"
+                android:name="org.koin.androidx.startup.KoinInitializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/projects/android/koin-androidx-startup/src/main/java/org/koin/androidx/startup/KoinInitializer.kt
+++ b/projects/android/koin-androidx-startup/src/main/java/org/koin/androidx/startup/KoinInitializer.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.koin.androix.startup
+package org.koin.androidx.startup
 
 import android.content.Context
 import androidx.startup.Initializer

--- a/projects/android/koin-androidx-startup/src/main/java/org/koin/androidx/startup/KoinStartup.kt
+++ b/projects/android/koin-androidx-startup/src/main/java/org/koin/androidx/startup/KoinStartup.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.koin.androix.startup
+package org.koin.androidx.startup
 
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.core.module.KoinApplicationDslMarker


### PR DESCRIPTION
Rename `org.koin.androix.startup` to `org.koin.androidx.startup` (correcting“androix” to official “androidx” naming)