### PR TITLE
Fix KLIB resolver issue related to `jb-navigation`

### DIFF
--- a/projects/gradle/libs.versions.toml
+++ b/projects/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ jb-lifecycle = "2.9.3"
 
 # Navigation
 androidx-navigation = "2.9.3" # Keep in sync with "jb-navigation"
-jb-navigation = "2.9.0-rc01"
+jb-navigation = "2.9.0-rc02"
 
 # Compose
 #androidx-compose = "1.8.1" # Keep in sync with "jb-compose"

--- a/projects/gradle/libs.versions.toml
+++ b/projects/gradle/libs.versions.toml
@@ -24,8 +24,8 @@ androidx-lifecycle = "2.9.3" # Keep in sync with "jb-lifecycle"
 jb-lifecycle = "2.9.3"
 
 # Navigation
-androidx-navigation = "2.9.3" # Keep in sync with "jb-navigation"
-jb-navigation = "2.9.0-rc02"
+androidx-navigation = "2.9.4" # Keep in sync with "jb-navigation"
+jb-navigation = "2.9.0"
 
 # Compose
 #androidx-compose = "1.8.1" # Keep in sync with "jb-compose"

--- a/projects/gradle/libs.versions.toml
+++ b/projects/gradle/libs.versions.toml
@@ -24,8 +24,8 @@ androidx-lifecycle = "2.9.3" # Keep in sync with "jb-lifecycle"
 jb-lifecycle = "2.9.3"
 
 # Navigation
-androidx-navigation = "2.9.4" # Keep in sync with "jb-navigation"
-jb-navigation = "2.9.0"
+androidx-navigation = "2.9.5" # Keep in sync with "jb-navigation"
+jb-navigation = "2.9.1"
 
 # Compose
 #androidx-compose = "1.8.1" # Keep in sync with "jb-compose"


### PR DESCRIPTION
- Fixes an issue where the KLIB resolver could not find the `org.jetbrains.androidx.savedstate:savedstate` dependency when updating from *Koin* version 4.0.4 to 4.1.0, which was causing build failures. The fix ensures that the dependency is correctly resolved, allowing the project to compile successfully.

Fix #2264 