### PR TITLE
Fix sharedKoinViewModel fails with type-safe navigation routes

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -25,6 +25,7 @@ buildscript {
 plugins {
     // Apply the new Kotlin Compose plugin
     id 'org.jetbrains.kotlin.plugin.compose' version "$kotlin_version" apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version "$kotlin_version" apply false
 }
 
 wrapper {

--- a/examples/sample-android-compose/build.gradle
+++ b/examples/sample-android-compose/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
+apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 
 apply from: "../gradle/versions.gradle"
 
@@ -44,6 +45,7 @@ dependencies {
     // Koin
     implementation "io.insert-koin:koin-androidx-compose:$koin_version"
     implementation "io.insert-koin:koin-androidx-compose-navigation:$koin_version"
+    implementation "io.insert-koin:koin-compose-viewmodel-navigation:$koin_version"
 
     // Compose
     implementation "androidx.compose.runtime:runtime:1.7.1"
@@ -51,6 +53,9 @@ dependencies {
     implementation "androidx.compose.foundation:foundation-layout:1.7.1"
     implementation "androidx.compose.material:material:1.7.1"
     implementation "androidx.navigation:navigation-compose:2.8.0"
+
+    // Serialization for Type-Safe Navigation
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
 
     // Tooling preview
     debugImplementation "androidx.compose.ui:ui-tooling:1.7.1"

--- a/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/App.kt
+++ b/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/App.kt
@@ -33,7 +33,10 @@ import java.util.UUID
 
 
 @Composable
-fun App(userViewModel: UserViewModel = koinViewModel()) {
+fun App(
+    userViewModel: UserViewModel = koinViewModel(),
+    onNavigateToNavigation: () -> Unit = {}
+) {
     var created by remember { mutableStateOf(true) }
 
     val users = userViewModel.getUsers()
@@ -52,6 +55,11 @@ fun App(userViewModel: UserViewModel = koinViewModel()) {
 
             item {
                 ButtonForCreate("-X- Main") { created = !created }
+            }
+            item {
+                ButtonForCreate("(>)Type Safe Navigation Example") {
+                    onNavigateToNavigation()
+                }
             }
             item {
                 MyScreen()

--- a/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/App.kt
+++ b/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/App.kt
@@ -35,7 +35,8 @@ import java.util.UUID
 @Composable
 fun App(
     userViewModel: UserViewModel = koinViewModel(),
-    onNavigateToNavigation: () -> Unit = {}
+    onTypeSafeNavigateToNavigation: () -> Unit = {},
+    onStringNavigateToNavigation: () -> Unit = {}
 ) {
     var created by remember { mutableStateOf(true) }
 
@@ -58,7 +59,12 @@ fun App(
             }
             item {
                 ButtonForCreate("(>)Type Safe Navigation Example") {
-                    onNavigateToNavigation()
+                    onTypeSafeNavigateToNavigation()
+                }
+            }
+            item {
+                ButtonForCreate("(>)String Navigation Example") {
+                    onStringNavigateToNavigation()
                 }
             }
             item {

--- a/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/MainActivity.kt
+++ b/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/MainActivity.kt
@@ -10,6 +10,7 @@ import org.koin.android.ext.android.getKoin
 import org.koin.androidx.scope.ScopeActivity
 import org.koin.sample.androidx.compose.data.sdk.SDKData
 import org.koin.sample.androidx.compose.navigation.NavigationGraphRoute
+import org.koin.sample.androidx.compose.navigation.navigationStringGraph
 import org.koin.sample.androidx.compose.navigation.navigationTypeSafeGraph
 import java.util.logging.Logger
 
@@ -30,13 +31,21 @@ class MainActivity : ScopeActivity() {
                     startDestination = "main"
                 ) {
                     composable("main") {
-                        App(onNavigateToNavigation = {
-                            navController.navigate(NavigationGraphRoute)
-                        })
+                        App(
+                            onTypeSafeNavigateToNavigation = {
+                                navController.navigate(NavigationGraphRoute)
+                            },
+                            onStringNavigateToNavigation = {
+                                navController.navigate("navigation_graph")
+                            }
+                        )
                     }
 
                     // Type-Safe Navigation graph
                     navigationTypeSafeGraph(navController)
+
+                    // String-based Navigation graph
+                    navigationStringGraph(navController)
                 }
             }
         }

--- a/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/MainActivity.kt
+++ b/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/MainActivity.kt
@@ -3,14 +3,14 @@ package org.koin.sample.androidx.compose
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.compose.material.MaterialTheme
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import org.koin.android.ext.android.getKoin
-import org.koin.android.ext.koin.androidContext
-import org.koin.androidx.compose.KoinAndroidContext
 import org.koin.androidx.scope.ScopeActivity
-import org.koin.compose.KoinApplication
-import org.koin.compose.KoinContext
 import org.koin.sample.androidx.compose.data.sdk.SDKData
-import org.koin.sample.androidx.compose.di.appModule
+import org.koin.sample.androidx.compose.navigation.NavigationGraphRoute
+import org.koin.sample.androidx.compose.navigation.navigationTypeSafeGraph
 import java.util.logging.Logger
 
 class MainActivity : ScopeActivity() {
@@ -23,7 +23,21 @@ class MainActivity : ScopeActivity() {
 
         setContent {
             MaterialTheme {
-                App()
+                val navController = rememberNavController()
+
+                NavHost(
+                    navController = navController,
+                    startDestination = "main"
+                ) {
+                    composable("main") {
+                        App(onNavigateToNavigation = {
+                            navController.navigate(NavigationGraphRoute)
+                        })
+                    }
+
+                    // Type-Safe Navigation graph
+                    navigationTypeSafeGraph(navController)
+                }
             }
         }
     }

--- a/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/di/appModule.kt
+++ b/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/di/appModule.kt
@@ -8,6 +8,7 @@ import org.koin.dsl.module
 import org.koin.sample.androidx.compose.MainActivity
 import org.koin.sample.androidx.compose.data.*
 import org.koin.sample.androidx.compose.viewmodel.SSHViewModel
+import org.koin.sample.androidx.compose.viewmodel.SharedViewModel
 import org.koin.sample.androidx.compose.viewmodel.UserViewModel
 
 val appModule = module {
@@ -16,6 +17,7 @@ val appModule = module {
     factoryOf(::MyFactory)
     single { MySingle() }
     viewModelOf(::SSHViewModel)
+    viewModelOf(::SharedViewModel)
 }
 
 val WALLET_SCOPE = named("wallet")

--- a/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/navigation/NavigationRoutes.kt
+++ b/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/navigation/NavigationRoutes.kt
@@ -1,0 +1,12 @@
+package org.koin.sample.androidx.compose.navigation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+object NavigationGraphRoute
+
+@Serializable
+object FirstScreenRoute
+
+@Serializable
+object SecondScreenRoute

--- a/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/navigation/NavigationScreens.kt
+++ b/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/navigation/NavigationScreens.kt
@@ -46,6 +46,40 @@ fun NavGraphBuilder.navigationTypeSafeGraph(navController: NavHostController) {
     }
 }
 
+fun NavGraphBuilder.navigationStringGraph(navController: NavHostController) {
+    navigation(
+        route = "navigation_graph",
+        startDestination = "first_screen"
+    ) {
+        composable(
+            route = "first_screen"
+        ) { backStackEntry ->
+            val sharedViewModel = backStackEntry.sharedKoinViewModel<SharedViewModel>(navController)
+
+            NavigationFirstScreen(
+                viewModel = sharedViewModel,
+                onNavigateToSecond = {
+                    navController.navigate("second_screen")
+                }
+            )
+        }
+
+        composable(
+            route = "second_screen"
+        ) { backStackEntry ->
+
+            val sharedViewModel = backStackEntry.sharedKoinViewModel<SharedViewModel>(navController)
+
+            NavigationSecondScreen(
+                viewModel = sharedViewModel,
+                onNavigateBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+    }
+}
+
 @Composable
 fun NavigationFirstScreen(
     viewModel: SharedViewModel,

--- a/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/navigation/NavigationScreens.kt
+++ b/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/navigation/NavigationScreens.kt
@@ -1,0 +1,107 @@
+package org.koin.sample.androidx.compose.navigation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import androidx.navigation.navigation
+import org.koin.compose.viewmodel.sharedKoinViewModel
+import org.koin.sample.androidx.compose.ButtonForCreate
+import org.koin.sample.androidx.compose.viewmodel.SharedViewModel
+
+fun NavGraphBuilder.navigationTypeSafeGraph(navController: NavHostController) {
+    navigation<NavigationGraphRoute>(startDestination = FirstScreenRoute) {
+        composable<FirstScreenRoute> { backStackEntry ->
+            val sharedViewModel = backStackEntry.sharedKoinViewModel<SharedViewModel>(navController)
+
+            NavigationFirstScreen(
+                viewModel = sharedViewModel,
+                onNavigateToSecond = {
+                    navController.navigate(SecondScreenRoute)
+                }
+            )
+        }
+
+        composable<SecondScreenRoute> { backStackEntry ->
+
+            val sharedViewModel = backStackEntry.sharedKoinViewModel<SharedViewModel>(navController)
+
+            NavigationSecondScreen(
+                viewModel = sharedViewModel,
+                onNavigateBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun NavigationFirstScreen(
+    viewModel: SharedViewModel,
+    onNavigateToSecond: () -> Unit
+) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text(
+            text = "First Screen",
+            style = MaterialTheme.typography.h5
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text("Last Updated: ${viewModel.lastUpdatedTime ?: "Not set"}")
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        ButtonForCreate("Record Time") { viewModel.recordTime() }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        ButtonForCreate(
+            "Go to Second Screen",
+            onNavigateToSecond
+        )
+    }
+}
+
+@Composable
+fun NavigationSecondScreen(
+    viewModel: SharedViewModel,
+    onNavigateBack: () -> Unit
+) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text(
+            text = "Second Screen",
+            style = MaterialTheme.typography.h5
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text("Last Updated: ${viewModel.lastUpdatedTime ?: "Not set"}")
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = { viewModel.recordTime() },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Record Time")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        ButtonForCreate(
+            "Back to First Screen",
+            onNavigateBack
+        )
+    }
+}

--- a/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/viewmodel/SharedViewModel.kt
+++ b/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/viewmodel/SharedViewModel.kt
@@ -1,0 +1,20 @@
+package org.koin.sample.androidx.compose.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class SharedViewModel : ViewModel() {
+
+    var lastUpdatedTime by mutableStateOf<String?>(null)
+        private set
+
+    fun recordTime() {
+        val formatter = SimpleDateFormat("HH:mm:ss", Locale.getDefault())
+        lastUpdatedTime = formatter.format(Date())
+    }
+}

--- a/projects/compose/koin-compose-viewmodel-navigation/src/commonMain/kotlin/org/koin/compose/viewmodel/NavViewModel.kt
+++ b/projects/compose/koin-compose-viewmodel-navigation/src/commonMain/kotlin/org/koin/compose/viewmodel/NavViewModel.kt
@@ -84,7 +84,11 @@ inline fun <reified VM : ViewModel> NavBackStackEntry.sharedKoinViewModel(
 ): VM {
     val navGraphRoute = navGraphRoute ?: return koinViewModel<VM>()
     val parentEntry = remember(this) {
-        navController.getBackStackEntry(navGraphRoute)
+        if (navGraphRoute is String) {
+            navController.getBackStackEntry(navGraphRoute)
+        } else {
+            navController.getBackStackEntry(navGraphRoute)
+        }
     }
     return koinViewModel(
         viewModelStoreOwner = parentEntry


### PR DESCRIPTION
Fix sharedKoinViewModel fails with [type-safe navigation](https://developer.android.com/guide/navigation/design/type-safety) routes #2292 