### PR TITLE
Fix a race condition when using `parametersOf`

### DIFF
--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
@@ -432,7 +432,7 @@ class Scope(
 
         sourceValue = null
 
-        parameterStack.get()?.clear()
+        parameterStack.remove()
 
         _koin.scopeRegistry.deleteScope(this)
     }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
@@ -65,7 +65,7 @@ class Scope(
     private val _callbacks = LinkedHashSet<ScopeCallback>()
 
     @KoinInternalApi
-    internal var parameterStack = ThreadLocal<ArrayDeque<ParametersHolder>>()
+    internal val parameterStack = ThreadLocal<ArrayDeque<ParametersHolder>>()
 
     private var _closed: Boolean = false
     val logger: Logger get() = _koin.logger

--- a/projects/core/koin-test-coroutines/build.gradle.kts
+++ b/projects/core/koin-test-coroutines/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 kotlin {
     
     jvm()
+    iosSimulatorArm64()
 
     sourceSets {
         commonMain.dependencies {

--- a/projects/core/koin-test-coroutines/src/commonTest/kotlin/org/koin/test/ParametersOfMultiThreadedTest.kt
+++ b/projects/core/koin-test-coroutines/src/commonTest/kotlin/org/koin/test/ParametersOfMultiThreadedTest.kt
@@ -1,0 +1,46 @@
+package org.koin.test
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.module.dsl.factoryOf
+import org.koin.core.parameter.parametersOf
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+private class ComponentA(val id: String)
+private class ComponentB(val id: Int)
+
+class ParametersOfMultiThreadedTest : KoinTest {
+
+    @Test
+    fun verify_creates_components_using_parametersOf_multi_threaded() {
+        startKoin {
+            modules(
+                module {
+                    factoryOf(::ComponentA)
+                    factoryOf(::ComponentB)
+                },
+            )
+        }
+
+        var componentA: ComponentA? = null
+        val job = CoroutineScope(Dispatchers.Default).launch {
+            componentA = get<ComponentA> { parametersOf("a") }
+        }
+        val componentB = get<ComponentB> { parametersOf(1) }
+        runBlocking {
+            job.join()
+        }
+
+        // Both components should be successfully resolved
+        assertNotNull(componentA)
+        assertNotNull(componentB)
+
+        stopKoin()
+    }
+}


### PR DESCRIPTION
`Scope` was incorrectly using `ThreadLocal` leading to a race condition. The actual issue was not putting `ArrayDeque` in a thread-local variable but creating the thread-local variable itself. Several concurrent threads could have created several instances of the `parameterStack` thread-local variable and only the last one would have used.
The correct usage of `ThreadLocal` is to instantiate it directly and let the `ThreadLocal` machinery to deal with synchronization.

This commit also adds a test that was failing prior to the fix. I've also added `iosSimulatorArm64` to the `:core:koin-test-coroutines` to test the fix on iOS.

This change fixes #2305.