### PR TITLE
Fix nav3 metadata arguments

### DIFF
--- a/projects/compose/koin-compose-navigation3/src/commonMain/kotlin/org/koin/dsl/navigation3/ModuleExt.kt
+++ b/projects/compose/koin-compose-navigation3/src/commonMain/kotlin/org/koin/dsl/navigation3/ModuleExt.kt
@@ -46,6 +46,7 @@ import org.koin.dsl.ScopeDSL
  * ```
  *
  * @param T The type representing the navigation route/destination
+ * @param metadata Optional metadata map to associate with the navigation entry (default is empty)
  * @param definition A composable function that receives the [Scope] and route instance [T] to render the destination
  * @return A [KoinDefinition] for the created [EntryProviderInstaller]
  *
@@ -55,12 +56,13 @@ import org.koin.dsl.ScopeDSL
 @KoinDslMarker
 @OptIn(KoinInternalApi::class)
 inline fun <reified T : Any> ScopeDSL.navigation(
+    metadata: Map<String, Any> = emptyMap(),
     noinline definition: @Composable Scope.(T) -> Unit,
 ): KoinDefinition<EntryProviderInstaller> {
     val def = _scopedInstanceFactory<EntryProviderInstaller>(named<T>(), {
         val scope = this
         {
-            entry<T>(content = { t -> definition(scope, t) })
+            entry<T>(content = { t -> definition(scope, t) }, metadata = metadata)
         }
     }, scopeQualifier)
     module.indexPrimaryType(def)
@@ -85,6 +87,7 @@ inline fun <reified T : Any> ScopeDSL.navigation(
  * ```
  *
  * @param T The type representing the navigation route/destination
+ * @param metadata Optional metadata map to associate with the navigation entry (default is empty)
  * @param definition A composable function that receives the [Scope] and route instance [T] to render the destination
  * @return A [KoinDefinition] for the created [EntryProviderInstaller]
  *
@@ -94,12 +97,13 @@ inline fun <reified T : Any> ScopeDSL.navigation(
 @KoinDslMarker
 @OptIn(KoinInternalApi::class)
 inline fun <reified T : Any> Module.navigation(
+    metadata: Map<String, Any> = emptyMap(),
     noinline definition: @Composable Scope.(T) -> Unit,
 ): KoinDefinition<EntryProviderInstaller> {
     val def = _singleInstanceFactory<EntryProviderInstaller>(named<T>(), {
         val scope = this
         {
-            entry<T>(content = { t -> definition(scope, t) })
+            entry<T>(content = { t -> definition(scope, t) }, metadata = metadata)
         }
     })
     indexPrimaryType(def)

--- a/projects/gradle/libs.versions.toml
+++ b/projects/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ jb-lifecycle = "2.9.5"
 
 # Navigation
 androidx-navigation = "2.9.5" # Keep in sync with "jb-navigation"
-androidx-navigation3 = "1.0.0-beta01"
+androidx-navigation3 = "1.0.0"
 jb-navigation = "2.9.1"
 
 # Compose


### PR DESCRIPTION
Allow metadata parameter passing to the entry point (like animations and others). 
Upgrade Nav3 to stable 1.0.0

Updated in `navigation<T>(metadata = <>){ /* Composable */ }`

```kotlin
// adding animation
navigation<ConversationDetail>(
    metadata = NavDisplay.transitionSpec {
        // Slide new content up, keeping the old content in place underneath
        slideInVertically(
            initialOffsetY = { it },
            animationSpec = tween(1000)
        ) togetherWith ExitTransition.KeepUntilTransitionsFinished
    } + NavDisplay.popTransitionSpec {
        // Slide old content down, revealing the new content in place underneath
        EnterTransition.None togetherWith
                slideOutVertically(
                    targetOffsetY = { it },
                    animationSpec = tween(1000)
                )
    } + NavDisplay.predictivePopTransitionSpec {
        // Slide old content down, revealing the new content in place underneath
        EnterTransition.None togetherWith
                slideOutVertically(
                    targetOffsetY = { it },
                    animationSpec = tween(1000)
                )
    }
) { key ->
    ConversationDetailScreen(key) {
        get<Navigator>().goTo(Profile)
    }
}
```