### PR TITLE
Make nav3 entryprovider generic

### DIFF
--- a/projects/compose/koin-compose-navigation3/src/androidMain/kotlin/org/koin/androidx/compose/navigation3/ComponentCallbacksExt.kt
+++ b/projects/compose/koin-compose-navigation3/src/androidMain/kotlin/org/koin/androidx/compose/navigation3/ComponentCallbacksExt.kt
@@ -23,9 +23,9 @@ import org.koin.core.annotation.KoinInternalApi
  */
 @KoinExperimentalAPI
 @OptIn(KoinInternalApi::class)
-fun ComponentCallbacks.entryProvider(
+fun <T : Any> ComponentCallbacks.entryProvider(
     mode: LazyThreadSafetyMode = LazyThreadSafetyMode.SYNCHRONIZED,
-) : Lazy<EntryProvider> = lazy(mode) { getEntryProvider() }
+) : Lazy<EntryProvider<T>> = lazy(mode) { getEntryProvider() }
 
 /**
  * Retrieves an [EntryProvider] by collecting all [EntryProviderInstaller] instances from the Koin scope
@@ -42,6 +42,6 @@ fun ComponentCallbacks.entryProvider(
  */
 @KoinExperimentalAPI
 @OptIn(KoinInternalApi::class)
-fun ComponentCallbacks.getEntryProvider() : EntryProvider {
+fun <T : Any> ComponentCallbacks.getEntryProvider() : EntryProvider<T> {
     return getKoinScope().getEntryProvider()
 }

--- a/projects/compose/koin-compose-navigation3/src/commonMain/kotlin/org/koin/compose/navigation3/EntryProvider.kt
+++ b/projects/compose/koin-compose-navigation3/src/commonMain/kotlin/org/koin/compose/navigation3/EntryProvider.kt
@@ -16,6 +16,7 @@
 package org.koin.compose.navigation3
 
 import androidx.compose.runtime.Composable
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.entryProvider
 import org.koin.compose.LocalKoinScopeContext
@@ -33,13 +34,13 @@ import org.koin.core.scope.Scope
  * @see EntryProviderInstaller for defining navigation entries in Koin modules
  */
 @KoinExperimentalAPI
-typealias EntryProvider = (Any) -> NavEntry<Any>
+typealias EntryProvider<T> = (T) -> NavEntry<T>
 
 @KoinExperimentalAPI
-internal fun Scope.getEntryProvider() : EntryProvider {
+internal fun <T : Any> Scope.getEntryProvider() : EntryProvider<T> {
     val entries = getAll<EntryProviderInstaller>()
-    val entryProvider: (Any) -> NavEntry<Any> = entryProvider {
-        entries.forEach { builder -> this.builder() }
+    val entryProvider: EntryProvider<T> = entryProvider {
+        entries.forEach { builder -> (this as EntryProviderScope<Any>).builder() }
     }
     return entryProvider
 }
@@ -71,6 +72,6 @@ internal fun Scope.getEntryProvider() : EntryProvider {
 @OptIn(KoinInternalApi::class)
 @KoinExperimentalAPI
 @Composable
-fun koinEntryProvider(scope : Scope = LocalKoinScopeContext.current.getValue()) : EntryProvider {
+fun <T : Any> koinEntryProvider(scope : Scope = LocalKoinScopeContext.current.getValue()) : EntryProvider<T> {
     return scope.getEntryProvider()
 }


### PR DESCRIPTION
The current implementation does not allow using `koinEntryProvider` when the backstack items type is not `Any`.
As a result, it’s necessary to manually cast the returned value:
```kotlin
NavDisplay(
    backStack = navigator.backStack, //List<MyNavKey>
    ...
    entryProvider = koinEntryProvider() as (MyNavKey) -> NavEntry<MyNavKey>
)
```

This PR removes that limitation and allows `koinEntryProvider` to work with typed backstack.