### PR TITLE
Fix premature release of scope & context

### DIFF
--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/CompositionKoinApplicationLoader.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/CompositionKoinApplicationLoader.kt
@@ -20,11 +20,13 @@ class CompositionKoinApplicationLoader(
     }
 
     override fun onAbandoned() {
+        koin?.logger?.warn("CompositionKoinApplicationLoader - onAbandoned")
         stop()
     }
 
     override fun onForgotten() {
-        stop()
+        koin?.logger?.debug("CompositionKoinApplicationLoader - onForgotten")
+        //don"t stop here, premature
     }
 
     override fun onRemembered() {
@@ -46,8 +48,8 @@ class CompositionKoinApplicationLoader(
     }
 
     private fun stop() {
+        koin?.logger?.warn("CompositionKoinApplicationLoader - stop")
         koin = null
-        KoinPlatform.getKoinOrNull()?.logger?.debug("$this -> stop Koin Application $koinApplication")
         stopKoin()
     }
 }

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/scope/CompositionKoinScopeLoader.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/scope/CompositionKoinScopeLoader.kt
@@ -31,10 +31,12 @@ class CompositionKoinScopeLoader(
     }
 
     override fun onForgotten() {
-        close()
+        scope.logger.debug("CompositionKoinScopeLoader onForgotten: '${scope.id}'")
+        //don"t stop here, premature
     }
 
     override fun onAbandoned() {
+        scope.logger.debug("CompositionKoinScopeLoader onAbandoned: '${scope.id}'")
         close()
     }
 


### PR DESCRIPTION
Fix premature release of scope & context. Don't drop in onForgotten, as UI is simply hidden but not destroyed.

Fix #2319 