### PR TITLE
Fix Compose Koin Context Loader and Entry Points

### DIFF
--- a/examples/sample-android-compose/build.gradle
+++ b/examples/sample-android-compose/build.gradle
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId "org.koin.sample.androidx.compose"
-        minSdkVersion 21
+        minSdkVersion 23
         versionCode 1
         versionName "1.0"
 

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinApplication.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinApplication.kt
@@ -128,7 +128,7 @@ fun currentKoinScope(): Scope = currentComposer.run {
 @Deprecated(
     message = "Use KoinApplication(config: KoinConfiguration) with koinConfiguration { } instead of KoinAppDeclaration lambda",
     replaceWith = ReplaceWith(
-        "KoinApplication(config = koinConfiguration(application), content = content)",
+        "KoinApplication(configuration = koinConfiguration(application), content = content)",
         "org.koin.dsl.koinConfiguration"
     ),
     level = DeprecationLevel.WARNING

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinApplication.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinApplication.kt
@@ -125,13 +125,66 @@ fun currentKoinScope(): Scope = currentComposer.run {
  *
  * @author Arnaud Giuliani
  */
+@Deprecated(
+    message = "Use KoinApplication(config: KoinConfiguration) with koinConfiguration { } instead of KoinAppDeclaration lambda",
+    replaceWith = ReplaceWith(
+        "KoinApplication(config = koinConfiguration(application), content = content)",
+        "org.koin.dsl.koinConfiguration"
+    ),
+    level = DeprecationLevel.WARNING
+)
 @OptIn(KoinInternalApi::class)
 @Composable
 fun KoinApplication(
-    application: KoinAppDeclaration, //Better to directly use KoinConfiguration class
+    application: KoinAppDeclaration,
     content: @Composable () -> Unit
 ) {
     val koin = rememberKoinApplication(application)
+    CompositionLocalProvider(
+        LocalKoinApplicationContext provides ComposeContextWrapper(koin) { getDefaultKoinContext() },
+        LocalKoinScopeContext provides ComposeContextWrapper(koin.scopeRegistry.rootScope) { getDefaultRootScope() },
+        content = content
+    )
+}
+
+/**
+ * Start a new Koin Application context and setup Compose context.
+ *
+ * This is the unified entry point for Koin in Compose applications (Android, iOS, Desktop, Web).
+ * Automatically configures:
+ * - Android: injects applicationContext and sets up androidLogger
+ * - Other platforms: sets up printLogger
+ *
+ * @param configuration Koin Application Configuration - use koinConfiguration { } to declare your Koin application
+ * @param logLevel Logger level for the application (default: Level.INFO)
+ * @param content Following compose function
+ *
+ * @throws org.koin.core.error.KoinApplicationAlreadyStartedException if Koin is already started
+ *
+ * Example:
+ * ```
+ * KoinApplication(
+ *     configuration = koinConfiguration {
+ *         modules(appModule)
+ *     }
+ * ) {
+ *     MyApp()
+ * }
+ * ```
+ *
+ * @see KoinConfiguration
+ * @see composeMultiplatformConfiguration
+ *
+ * @author Arnaud Giuliani
+ */
+@OptIn(KoinInternalApi::class)
+@Composable
+fun KoinApplication(
+    configuration: KoinConfiguration,
+    logLevel: Level = Level.INFO,
+    content: @Composable () -> Unit
+) {
+    val koin = rememberKoinMPApplication(configuration, logLevel)
     CompositionLocalProvider(
         LocalKoinApplicationContext provides ComposeContextWrapper(koin) { getDefaultKoinContext() },
         LocalKoinScopeContext provides ComposeContextWrapper(koin.scopeRegistry.rootScope) { getDefaultRootScope() },
@@ -157,6 +210,7 @@ fun KoinApplication(
  *
  * @author Arnaud Giuliani
  */
+@Deprecated("Use KoinApplication(configuration: KoinConfiguration, logLevel: Level) instead", ReplaceWith("KoinApplication(configuration = config, logLevel = logLevel, content = content)"))
 @OptIn(KoinInternalApi::class)
 @Composable
 @KoinExperimentalAPI

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/CompositionKoinApplicationLoader.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/CompositionKoinApplicationLoader.kt
@@ -10,7 +10,7 @@ import org.koin.mp.KoinPlatform
 
 @KoinInternalApi
 class CompositionKoinApplicationLoader(
-    val koinApplication: KoinApplication,
+    val koinApplication: KoinApplication? = null,
 ) : RememberObserver {
 
     var koin : Koin? = null
@@ -20,12 +20,12 @@ class CompositionKoinApplicationLoader(
     }
 
     override fun onAbandoned() {
-        koin?.logger?.warn("CompositionKoinApplicationLoader - onAbandoned")
+        koin?.logger?.warn("CompositionKoinApplicationLoader - onAbandoned - $this")
         stop()
     }
 
     override fun onForgotten() {
-        koin?.logger?.debug("CompositionKoinApplicationLoader - onForgotten")
+        koin?.logger?.debug("CompositionKoinApplicationLoader - onForgotten - $this")
         //don"t stop here, premature
     }
 
@@ -34,16 +34,18 @@ class CompositionKoinApplicationLoader(
     }
 
     private fun start() {
-        if (KoinPlatform.getKoinOrNull() == null){
+        if (KoinPlatform.getKoinOrNull() == null && koinApplication != null){
             try {
                 koin = startKoin(koinApplication).koin
                 koin!!.logger.debug("$this -> attach Koin instance $koin")
             } catch (e: Exception) {
                 error("Can't start Koin from Compose context - $e")
             }
-        } else {
+        } else if (KoinPlatform.getKoinOrNull() != null) {
             koin = KoinPlatform.getKoin()
             koin!!.logger.debug("$this -> re-attach Koin instance $koin")
+        } else {
+            error("can't start Koin context, no koinApplication argument found nor existing context")
         }
     }
 

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/CompositionKoinApplicationLoader.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/CompositionKoinApplicationLoader.kt
@@ -26,7 +26,8 @@ class CompositionKoinApplicationLoader(
 
     override fun onForgotten() {
         koin?.logger?.debug("CompositionKoinApplicationLoader - onForgotten - $this")
-        //don"t stop here, premature
+        //don"t stop context, premature. Only de-allocate
+        koin = null
     }
 
     override fun onRemembered() {

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/RememberKoinApplication.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/RememberKoinApplication.kt
@@ -41,9 +41,9 @@ inline fun rememberKoinApplication(noinline koinAppDeclaration: KoinAppDeclarati
 @Composable
 @KoinInternalApi
 inline fun rememberKoinMPApplication(configuration: KoinConfiguration, logLevel: Level): Koin {
-    val configuration = composeMultiplatformConfiguration(logLevel, config = configuration)
-    val wrapper = remember(configuration, logLevel) {
-        CompositionKoinApplicationLoader(if (KoinPlatform.getKoinOrNull() == null) koinApplication(configuration) else null)
+    val mergedConfiguration = composeMultiplatformConfiguration(logLevel, config = configuration)
+    val wrapper = remember(mergedConfiguration, logLevel) {
+        CompositionKoinApplicationLoader(if (KoinPlatform.getKoinOrNull() == null) koinApplication(mergedConfiguration) else null)
     }
     return wrapper.koin ?: error("Koin context has not been initialized in rememberKoinApplication")
 }

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/RememberKoinApplication.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/RememberKoinApplication.kt
@@ -26,12 +26,13 @@ import org.koin.core.logger.Level
 import org.koin.dsl.KoinAppDeclaration
 import org.koin.dsl.KoinConfiguration
 import org.koin.dsl.koinApplication
+import org.koin.mp.KoinPlatform
 
 @Composable
 @KoinInternalApi
 inline fun rememberKoinApplication(noinline koinAppDeclaration: KoinAppDeclaration): Koin {
     val wrapper = remember(koinAppDeclaration) {
-        CompositionKoinApplicationLoader(koinApplication(koinAppDeclaration))
+        CompositionKoinApplicationLoader(if (KoinPlatform.getKoinOrNull() == null) koinApplication(koinAppDeclaration) else null)
     }
     return wrapper.koin ?: error("Koin context has not been initialized in rememberKoinApplication")
 }
@@ -41,8 +42,8 @@ inline fun rememberKoinApplication(noinline koinAppDeclaration: KoinAppDeclarati
 @KoinInternalApi
 inline fun rememberKoinMPApplication(configuration: KoinConfiguration, logLevel: Level): Koin {
     val configuration = composeMultiplatformConfiguration(logLevel, config = configuration)
-    val wrapper = remember(configuration,logLevel) {
-        CompositionKoinApplicationLoader(koinApplication(configuration))
+    val wrapper = remember(configuration, logLevel) {
+        CompositionKoinApplicationLoader(if (KoinPlatform.getKoinOrNull() == null) koinApplication(configuration) else null)
     }
     return wrapper.koin ?: error("Koin context has not been initialized in rememberKoinApplication")
 }

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/scope/CompositionKoinScopeLoader.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/scope/CompositionKoinScopeLoader.kt
@@ -31,18 +31,18 @@ class CompositionKoinScopeLoader(
     }
 
     override fun onForgotten() {
-        scope.logger.debug("CompositionKoinScopeLoader onForgotten: '${scope.id}'")
-        //don"t stop here, premature
+        scope.logger.debug("CompositionKoinScopeLoader onForgotten: '${scope.id}' ($this)")
+        close()
     }
 
     override fun onAbandoned() {
-        scope.logger.debug("CompositionKoinScopeLoader onAbandoned: '${scope.id}'")
+        scope.logger.debug("CompositionKoinScopeLoader onAbandoned: '${scope.id}' ($this)")
         close()
     }
 
     private fun close() {
         if (!scope.isRoot && !(scope.closed)){
-            scope.logger.debug("CompositionKoinScopeLoader close scope: '${scope.id}'")
+            scope.logger.debug("CompositionKoinScopeLoader close scope: '${scope.id}' ($this)")
             scope.close()
         }
     }


### PR DESCRIPTION
 Fix Koin context recreation on theme changes and unify KoinApplication API

  Problem

  When using KoinMultiplatformApplication() (or KoinApplication()), theme changes on Android were causing Koin to restart, re-registering all modules and recreating dependencies. This was caused by:

  1. Premature cleanup in onForgotten() - The RememberObserver.onForgotten() callback was calling stop(), but this callback fires during temporary composition changes (like theme changes), not just when the composition is truly abandoned
  2. Module re-registration - Even when Koin instance was preserved, modules were being re-registered on recomposition because koinApplication() was being called outside the remember {} block

  Related to #2274

  Solution

  This PR builds on #2326 and adds:

  1. Fix Context Recreation (commits 87811e67, b7c9f3c7)

  - CompositionKoinApplicationLoader: Now accepts nullable KoinApplication? and only starts Koin if it doesn't exist yet
  - onForgotten(): Only deallocates reference (koin = null) instead of calling stopKoin() - preventing premature shutdown
  - RememberKoinApplication: Passes null for KoinApplication when Koin already exists, preventing module re-registration

  2. Unify KoinApplication API (commit ec2535b3 + current changes)

  - New unified entry point: KoinApplication(configuration: KoinConfiguration, logLevel: Level)
    - Works for all platforms (Android, iOS, Desktop, Web)
    - Automatically injects Android context and logger on Android
    - Uses koinConfiguration { } for better clarity and type safety
  - Deprecations:
    - KoinApplication(application: KoinAppDeclaration) → Use new KoinApplication(configuration: ...)
    - KoinMultiplatformApplication(...) → Use new KoinApplication(configuration: ...)

  Migration Guide


```kotlin
  // Before:
  KoinMultiplatformApplication(
      config = koinConfiguration {
          modules(appModule)
      }
  ) {
      MyApp()
  }

  // After:
  KoinApplication(
      configuration = koinConfiguration {
          modules(appModule)
      }
  ) {
      MyApp()
  }
```

  Benefits

- No more Koin restarts on theme changes
- Single, clear API for all platforms
- Better parameter naming (configuration vs config)
- Safer configuration with KoinConfiguration
- Automatic platform-specific setup (Android context/logger)

