### PR TITLE
Fix 2325 - CoreResolution with Child Scopes / ViewModelScope

### DIFF
--- a/examples/gradle/versions.gradle
+++ b/examples/gradle/versions.gradle
@@ -1,8 +1,8 @@
 ext {
     // Kotlin
-    kotlin_version = '2.2.20'
+    kotlin_version = '2.3.20-Beta1'
     // Koin Versions
-    koin_version = '4.2.0-beta2'
+    koin_version = '4.2.0-beta3-rc6'
     koin_android_version = koin_version
     koin_compose_version = koin_version
 

--- a/projects/android/koin-android/src/test/java/org/koin/test/android/scope/ViewModelScopeArchetypeTest.kt
+++ b/projects/android/koin-android/src/test/java/org/koin/test/android/scope/ViewModelScopeArchetypeTest.kt
@@ -19,6 +19,7 @@ import org.koin.androidx.scope.dsl.fragmentScope
 import org.koin.androidx.scope.fragmentScope
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.core.annotation.KoinViewModelScopeApi
 import org.koin.core.component.getScopeId
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
@@ -58,9 +59,9 @@ class FakeVMActivity : ComponentActivity() {
 }
 
 @RunWith(RobolectricTestRunner::class)
+@OptIn(KoinExperimentalAPI::class)
 class ViewModelScopeArchetypeTest {
 
-    @OptIn(KoinExperimentalAPI::class)
     @Before
     fun setup() {
         startKoin {

--- a/projects/android/koin-android/src/test/java/org/koin/test/android/scope/ViewModelScopeArchetypeTest.kt
+++ b/projects/android/koin-android/src/test/java/org/koin/test/android/scope/ViewModelScopeArchetypeTest.kt
@@ -81,8 +81,8 @@ class ViewModelScopeArchetypeTest {
     fun `viewModelScope resolves`() {
         val koin = KoinPlatform.getKoin()
         val module = module {
-            viewModel { FakeVM(get()) }
             viewModelScope {
+                viewModel { FakeVM(get()) }
                 scoped { ScopedVM() }
             }
         }

--- a/projects/core/koin-annotations/api/koin-annotations.api
+++ b/projects/core/koin-annotations/api/koin-annotations.api
@@ -1,0 +1,87 @@
+public abstract interface annotation class org/koin/android/annotation/ActivityRetainedScope : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class org/koin/android/annotation/ActivityScope : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class org/koin/android/annotation/FragmentScope : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class org/koin/android/annotation/KoinWorker : java/lang/annotation/Annotation {
+	public abstract fun binds ()[Ljava/lang/Class;
+}
+
+public abstract interface annotation class org/koin/core/annotation/ComponentScan : java/lang/annotation/Annotation {
+	public abstract fun value ()[Ljava/lang/String;
+}
+
+public abstract interface annotation class org/koin/core/annotation/Configuration : java/lang/annotation/Annotation {
+	public abstract fun value ()[Ljava/lang/String;
+}
+
+public abstract interface annotation class org/koin/core/annotation/Factory : java/lang/annotation/Annotation {
+	public abstract fun binds ()[Ljava/lang/Class;
+}
+
+public abstract interface annotation class org/koin/core/annotation/KoinApplication : java/lang/annotation/Annotation {
+	public abstract fun configurations ()[Ljava/lang/String;
+	public abstract fun modules ()[Ljava/lang/Class;
+}
+
+public abstract interface annotation class org/koin/core/annotation/KoinViewModel : java/lang/annotation/Annotation {
+	public abstract fun binds ()[Ljava/lang/Class;
+}
+
+public abstract interface annotation class org/koin/core/annotation/Module : java/lang/annotation/Annotation {
+	public abstract fun createdAtStart ()Z
+	public abstract fun includes ()[Ljava/lang/Class;
+}
+
+public abstract interface annotation class org/koin/core/annotation/Monitor : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class org/koin/core/annotation/Named : java/lang/annotation/Annotation {
+	public abstract fun type ()Ljava/lang/Class;
+	public abstract fun value ()Ljava/lang/String;
+}
+
+public abstract interface annotation class org/koin/core/annotation/Property : java/lang/annotation/Annotation {
+	public abstract fun value ()Ljava/lang/String;
+}
+
+public abstract interface annotation class org/koin/core/annotation/PropertyValue : java/lang/annotation/Annotation {
+	public abstract fun value ()Ljava/lang/String;
+}
+
+public abstract interface annotation class org/koin/core/annotation/Qualifier : java/lang/annotation/Annotation {
+	public abstract fun name ()Ljava/lang/String;
+	public abstract fun value ()Ljava/lang/Class;
+}
+
+public abstract interface annotation class org/koin/core/annotation/Scope : java/lang/annotation/Annotation {
+	public abstract fun name ()Ljava/lang/String;
+	public abstract fun value ()Ljava/lang/Class;
+}
+
+public abstract interface annotation class org/koin/core/annotation/ScopeId : java/lang/annotation/Annotation {
+	public abstract fun name ()Ljava/lang/String;
+	public abstract fun value ()Ljava/lang/Class;
+}
+
+public abstract interface annotation class org/koin/core/annotation/Scoped : java/lang/annotation/Annotation {
+	public abstract fun binds ()[Ljava/lang/Class;
+}
+
+public abstract interface annotation class org/koin/core/annotation/Single : java/lang/annotation/Annotation {
+	public abstract fun binds ()[Ljava/lang/Class;
+	public abstract fun createdAtStart ()Z
+}
+
+public abstract interface annotation class org/koin/core/annotation/Singleton : java/lang/annotation/Annotation {
+	public abstract fun binds ()[Ljava/lang/Class;
+	public abstract fun createdAtStart ()Z
+}
+
+public abstract interface annotation class org/koin/core/annotation/ViewModelScope : java/lang/annotation/Annotation {
+}
+

--- a/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ViewModelScopeArchetypeDSL.kt
+++ b/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ViewModelScopeArchetypeDSL.kt
@@ -21,7 +21,20 @@ import org.koin.core.module.Module
 import org.koin.dsl.ScopeDSL
 
 /**
- * Declare a ViewModel scope
+ * Declare a ViewModel scope section.
+ *
+ * ViewModels that need constructor injection from this scope must be declared inside this block.
+ *
+ * ```kotlin
+ * viewModelScope {
+ *     viewModel { MyViewModel(get()) }  // ViewModel with scoped dependency
+ *     scoped { MyScopedDependency() }   // Scoped to ViewModel lifecycle
+ * }
+ * ```
+ *
+ * Requires `viewModelScopeFactory()` option to be enabled.
+ *
+ * @see KoinViewModelScopeApi for more details
  */
 @KoinViewModelScopeApi
 @KoinExperimentalAPI

--- a/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ViewModelScopeArchetypeDSL.kt
+++ b/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ViewModelScopeArchetypeDSL.kt
@@ -16,12 +16,14 @@
 package org.koin.viewmodel.scope
 
 import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.core.annotation.KoinViewModelScopeApi
 import org.koin.core.module.Module
 import org.koin.dsl.ScopeDSL
 
 /**
  * Declare a ViewModel scope
  */
+@KoinViewModelScopeApi
 @KoinExperimentalAPI
 fun Module.viewModelScope(scopeSet: ScopeDSL.() -> Unit) {
     val qualifier = ViewModelScopeArchetype

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/annotation/KoinAnnotations.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/annotation/KoinAnnotations.kt
@@ -84,10 +84,10 @@ annotation class KoinDelicateAPI
 
 /**
  * ViewModelScope APIs - Create Scope for ViewModel, at ViewModel creation time
- * To use ViewModelScope for ViewModel's constructor injection, you need to declare your ViewModel inside a viewModelScope section, like viewModelScope { viewMode() }. Or use @ViewModelScope annotation with @KoinViewModel.
- * Else Koin won't find your instance in teh right scope, if ViewModel is declared in root scope.
+ * To use ViewModelScope for ViewModel's constructor injection, you need to declare your ViewModel inside a viewModelScope section, like viewModelScope { viewModel() }. Or use @ViewModelScope annotation with @KoinViewModel.
+ * Else Koin won't find your instance in the right scope, if ViewModel is declared in root scope.
  */
-@RequiresOptIn(message = "To use ViewModelScope for ViewModel's constructor injection, you need to declare your ViewModel inside a viewModelScope section, like viewModelScope { viewMode() }. Or use @ViewModelScope annotation with @KoinViewModel.", level = RequiresOptIn.Level.WARNING)
+@RequiresOptIn(message = "To use ViewModelScope for ViewModel's constructor injection, you need to declare your ViewModel inside a viewModelScope section, like viewModelScope { viewModel() }. Or use @ViewModelScope annotation with @KoinViewModel.", level = RequiresOptIn.Level.WARNING)
 @Retention(AnnotationRetention.BINARY)
 @Target(
     AnnotationTarget.CLASS,

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/annotation/KoinAnnotations.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/annotation/KoinAnnotations.kt
@@ -81,3 +81,20 @@ APIs marked with @KoinDelicateAPI require careful usage and understanding of the
     AnnotationTarget.CONSTRUCTOR,
 )
 annotation class KoinDelicateAPI
+
+/**
+ * ViewModelScope APIs - Create Scope for ViewModel, at ViewModel creation time
+ * To use ViewModelScope for ViewModel's constructor injection, you need to declare your ViewModel inside a viewModelScope section, like viewModelScope { viewMode() }. Or use @ViewModelScope annotation with @KoinViewModel.
+ * Else Koin won't find your instance in teh right scope, if ViewModel is declared in root scope.
+ */
+@RequiresOptIn(message = "To use ViewModelScope for ViewModel's constructor injection, you need to declare your ViewModel inside a viewModelScope section, like viewModelScope { viewMode() }. Or use @ViewModelScope annotation with @KoinViewModel.", level = RequiresOptIn.Level.WARNING)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.TYPEALIAS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.CONSTRUCTOR,
+)
+annotation class KoinViewModelScopeApi

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/option/KoinOption.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/option/KoinOption.kt
@@ -31,9 +31,9 @@ enum class KoinOption {
 }
 
 /**
- * ViewModelScope APIs - Create Scope for ViewModel, at ViewModel creation time
- * To use ViewModelScope for ViewModel's constructor injection, you need to declare your ViewModel inside a viewModelScope section, like viewModelScope { viewMode() }. Or use @ViewModelScope annotation with @KoinViewModel.
- * Else Koin won't find your instance in teh right scope, if ViewModel is declared in root scope.
+ * Enable ViewModelScope feature - Creates a dedicated Scope for each ViewModel at creation time.
+ *
+ * @see KoinViewModelScopeApi for usage requirements
  */
 @KoinViewModelScopeApi
 fun viewModelScopeFactory(): Pair<KoinOption, Boolean> {

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/option/KoinOption.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/option/KoinOption.kt
@@ -16,15 +16,26 @@
 package org.koin.core.option
 
 import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.annotation.KoinViewModelScopeApi
 import org.koin.core.registry.OptionRegistry
 
 /**
  * Koin Options to be activated
  */
 enum class KoinOption {
+
+    /**
+     * see [viewModelScopeFactory]
+     */
     VIEWMODEL_SCOPE_FACTORY
 }
 
+/**
+ * ViewModelScope APIs - Create Scope for ViewModel, at ViewModel creation time
+ * To use ViewModelScope for ViewModel's constructor injection, you need to declare your ViewModel inside a viewModelScope section, like viewModelScope { viewMode() }. Or use @ViewModelScope annotation with @KoinViewModel.
+ * Else Koin won't find your instance in teh right scope, if ViewModel is declared in root scope.
+ */
+@KoinViewModelScopeApi
 fun viewModelScopeFactory(): Pair<KoinOption, Boolean> {
     return KoinOption.VIEWMODEL_SCOPE_FACTORY to true
 }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolverV2.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolverV2.kt
@@ -19,6 +19,7 @@ import org.koin.core.Koin
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.error.NoDefinitionFoundException
+import org.koin.core.instance.InstanceFactory
 import org.koin.core.instance.ResolutionContext
 import org.koin.core.scope.Scope
 import org.koin.ext.getFullName
@@ -53,50 +54,56 @@ class CoreResolverV2(
         scope: Scope,
         ctx: ResolutionContext
     ): T? {
-        // direct definition
-        var factory = _koin.instanceRegistry.resolveDefinition(ctx.clazz,ctx.qualifier, scope.scopeQualifier)
-            ?: if (!scope.isRoot) scope.scopeArchetype?.let {
-                ctx.scopeArchetype = it
-                _koin.instanceRegistry.resolveDefinition(ctx.clazz,ctx.qualifier, it)
-            } else null
-        var newCtx = ctx
-        return if (factory != null){
-            factory.get(newCtx) as T?
+        return resolveDirectDefinition(scope, ctx)
+            ?: resolveFromScopeSource(scope, ctx)
+            ?: resolveFromLinkedScopes(scope, ctx)
+    }
+
+    private fun <T> resolveDirectDefinition(scope: Scope, ctx: ResolutionContext): T? {
+        val factory = _koin.instanceRegistry.resolveDefinition(ctx.clazz, ctx.qualifier, scope.scopeQualifier)
+            ?: resolveFromScopeArchetype(scope, ctx)
+        return factory?.get(ctx) as T?
+    }
+
+    private fun resolveFromScopeArchetype(scope: Scope, ctx: ResolutionContext): InstanceFactory<*>? {
+        if (scope.isRoot) return null
+        return scope.scopeArchetype?.let { archetype ->
+            ctx.scopeArchetype = archetype
+            _koin.instanceRegistry.resolveDefinition(ctx.clazz, ctx.qualifier, archetype)
         }
-        else {
-            // scope source
-            if (!scope.isRoot && ctx.qualifier == null && ctx.clazz.isInstance(scope.sourceValue)) scope.sourceValue as? T
-            // parent scopes
-            else {
-                var lastScope : Scope? = null
-                val scopes = listOf(scope) + flatten(scope.linkedScopes)
-                factory = scopes.firstNotNullOfOrNull {
-                    val foundDefinition = it.scopeArchetype?.let {
-                        _koin.instanceRegistry.resolveDefinition(
-                            ctx.clazz,
-                            ctx.qualifier,
-                            it
-                        )
-                    } ?:
-                    _koin.instanceRegistry.resolveDefinition(
-                        ctx.clazz,
-                        ctx.qualifier,
-                        it.scopeQualifier
-                    )
-                    if (foundDefinition != null){
-                        lastScope = it
-                    }
-                    foundDefinition
-                }
-                if (factory != null && lastScope != null){
-                    newCtx = ctx.newContextForScope(lastScope)
-                    if (lastScope.scopeArchetype != null && !lastScope.isRoot){
-                        newCtx.scopeArchetype = lastScope.scopeArchetype
-                    }
-                }
-                factory?.get(newCtx) as T?
+    }
+
+    private fun <T> resolveFromScopeSource(scope: Scope, ctx: ResolutionContext): T? {
+        if (scope.isRoot || ctx.qualifier != null) return null
+        return if (ctx.clazz.isInstance(scope.sourceValue)) scope.sourceValue as? T else null
+    }
+
+    private fun <T> resolveFromLinkedScopes(scope: Scope, ctx: ResolutionContext): T? {
+        val scopes = listOf(scope) + flatten(scope.linkedScopes)
+        var resolvedScope: Scope? = null
+
+        val factory = scopes.firstNotNullOfOrNull { linkedScope ->
+            val definition = findDefinitionInScope(linkedScope, ctx)
+            if (definition != null) {
+                resolvedScope = linkedScope
             }
+            definition
         }
+
+        val foundScope = resolvedScope ?: return null
+        if (factory == null) return null
+
+        val newCtx = ctx.newContextForScope(foundScope)
+        if (foundScope.scopeArchetype != null && !foundScope.isRoot) {
+            newCtx.scopeArchetype = foundScope.scopeArchetype
+        }
+        return factory.get(newCtx) as T?
+    }
+
+    private fun findDefinitionInScope(scope: Scope, ctx: ResolutionContext): InstanceFactory<*>? {
+        return scope.scopeArchetype?.let { archetype ->
+            _koin.instanceRegistry.resolveDefinition(ctx.clazz, ctx.qualifier, archetype)
+        } ?: _koin.instanceRegistry.resolveDefinition(ctx.clazz, ctx.qualifier, scope.scopeQualifier)
     }
 
     private inline fun <T> resolveFromInjectedParameters(ctx: ResolutionContext): T? {
@@ -120,7 +127,7 @@ class CoreResolverV2(
     private inline fun <T> throwNoDefinitionFound(ctx: ResolutionContext): T {
         val qualifierString = ctx.qualifier?.let { " and qualifier '$it'" } ?: ""
         throw NoDefinitionFoundException(
-            "No definition found for type '${ctx.clazz.getFullName()}'$qualifierString. Check your Modules configuration and add missing type and/or qualifier!",
+            "No definition found for type '${ctx.clazz.getFullName()}'$qualifierString on scope '${ctx.scope}'. Check your Modules configuration and add missing type and/or qualifier!",
         )
     }
 

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolverV2.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolverV2.kt
@@ -90,7 +90,7 @@ class CoreResolverV2(
                 }
                 if (factory != null && lastScope != null){
                     newCtx = ctx.newContextForScope(lastScope)
-                    if (scope.scopeArchetype != null && !scope.isRoot){
+                    if (lastScope.scopeArchetype != null && !lastScope.isRoot){
                         newCtx.scopeArchetype = lastScope.scopeArchetype
                     }
                 }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolverV2.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolverV2.kt
@@ -88,9 +88,9 @@ class CoreResolverV2(
                     }
                     foundDefinition
                 }
-                if (factory != null && lastScope != null && !lastScope.isRoot){
+                if (factory != null && lastScope != null){
                     newCtx = ctx.newContextForScope(lastScope)
-                    if (scope.scopeArchetype != null){
+                    if (scope.scopeArchetype != null && !scope.isRoot){
                         newCtx.scopeArchetype = lastScope.scopeArchetype
                     }
                 }
@@ -116,19 +116,6 @@ class CoreResolverV2(
             parameters?.getOrNull(ctx.clazz)
         }
     }
-
-//    private inline fun <T> resolveFromScopeSource(scope: Scope, ctx: ResolutionContext): T? {
-//        if (scope.isRoot || scope.sourceValue == null || !(ctx.clazz.isInstance(scope.sourceValue) && ctx.qualifier == null)) return null
-//        ctx.logger.debug("|- ? ${ctx.debugTag} look at scope source")
-//        return if (ctx.clazz.isInstance(scope.sourceValue)) { scope.sourceValue as? T } else null
-//    }
-//
-//    @OptIn(KoinExperimentalAPI::class)
-//    private inline fun <T> resolveFromScopeArchetype(scope: Scope, ctx: ResolutionContext): T? {
-//        if (scope.isRoot || scope.scopeArchetype == null) return null
-//        ctx.logger.debug("|- ? ${ctx.debugTag} look at scope archetype")
-//        return _koin.instanceRegistry.resolveScopeArchetypeInstance<T>(ctx.qualifier, ctx.clazz, ctx)
-//    }
 
     private inline fun <T> throwNoDefinitionFound(ctx: ResolutionContext): T {
         val qualifierString = ctx.qualifier?.let { " and qualifier '$it'" } ?: ""

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ScopeExampleTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ScopeExampleTest.kt
@@ -1,0 +1,66 @@
+package org.koin.core
+
+import org.koin.Simple
+import org.koin.core.component.KoinScopeComponent
+import org.koin.core.component.getOrCreateScope
+import org.koin.core.component.inject
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.error.ClosedScopeException
+import org.koin.core.logger.Level
+import org.koin.core.module.dsl.scopedOf
+import org.koin.core.module.dsl.singleOf
+import org.koin.core.parameter.parametersOf
+import org.koin.core.qualifier.named
+import org.koin.core.scope.Scope
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import kotlin.test.*
+
+class ScopeExampleTest {
+
+    class HttpClient(val name: String)
+
+    class ScopedApi(val client: HttpClient)
+    class SingleApi(val client: HttpClient)
+    class ScopedRepo(
+        val singleApi: SingleApi,
+        val scopedApi: ScopedApi,
+    )
+    class SingleRepo(
+        val singleApi: SingleApi,
+    )
+    class UseCaseOnScopedRepo(val scopedRepo: ScopedRepo)
+    class UseCaseOnSingleRepo(val singleRepo: SingleRepo)
+
+    @Test
+    fun test_issue_2325() {
+        val koin = startKoin {
+            printLogger(level = Level.DEBUG)
+
+            modules(
+                module {
+                    scope(named("name")) {
+                        scoped { HttpClient("scoped") }
+                        scoped { ScopedApi(get()) }
+                        scoped { ScopedRepo(get(), get()) }
+                    }
+                    factory { UseCaseOnScopedRepo(getScope("id").get()) }
+
+                    single { HttpClient("single") }
+                    single { SingleApi(get()) }
+                    single { SingleRepo(get()) }
+                    factory { UseCaseOnSingleRepo(get()) }
+                }
+            )
+        }.koin
+        koin.createScope("id", named("name"))
+
+        val ucOnScoped = koin.get<UseCaseOnScopedRepo>()
+        assertEquals("single",ucOnScoped.scopedRepo.singleApi.client.name)
+        assertEquals("scoped",ucOnScoped.scopedRepo.scopedApi.client.name)
+
+        val ucOnSingle = koin.get<UseCaseOnSingleRepo>()
+        assertEquals("single",ucOnSingle.singleRepo.singleApi.client.name)
+    }
+}

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ScopeInfoTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ScopeInfoTest.kt
@@ -17,7 +17,7 @@ class ScopeInfoTest {
             printLogger(Level.DEBUG)
             modules(
                 module {
-                    factory { Simple.ComponentC(get()) }
+                    factory { Simple.ComponentC(it.get()) }
                     single { Simple.ComponentA() }
                     scope<Simple.ComponentA> {
                         scopedOf(Simple::ComponentB)

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ScopeTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ScopeTest.kt
@@ -22,6 +22,11 @@ class ScopeTest {
     private class A
     private class B
 
+    @BeforeTest
+    fun before(){
+        stopKoin()
+    }
+
     @Test
     fun scope_component() {
         abstract class SuperClass : KoinScopeComponent {

--- a/projects/gradle.properties
+++ b/projects/gradle.properties
@@ -11,7 +11,7 @@ kotlin.incremental.multiplatform=true
 kotlin.code.style=official
 
 #Koin
-koinVersion=4.2.0-beta3-plugin-rc5
+koinVersion=4.2.0-beta3-rc6
 
 #Compose
 org.jetbrains.compose.experimental.jscanvas.enabled=true


### PR DESCRIPTION
 Fix #2325 - Scope Resolution + ViewModelScope Scope Leak Fix

  Summary

  Fixes scope resolution leak where ViewModels at root scope could incorrectly access viewModelScope { } dependencies. CoreResolverV2 is now stricter. Also impacting previously other scope access.

  Breaking Change (Experimental API)

```kotlin
  // ❌ No longer works (was leaking)
  module {
      viewModel { MyVM(get()) }
      viewModelScope { scoped { Session() } }
  }

  // ✅ Required pattern
  viewModelScope {
      viewModel { MyVM(get()) }
      scoped { Session() }
  }
```

  Changes

  - CoreResolverV2: Refactored into clear methods (resolveDirectDefinition, resolveFromScopeArchetype, resolveFromScopeSource, resolveFromLinkedScopes)
  - @KoinViewModelScopeApi: New opt-in annotation (WARNING level) on viewModelScope() DSL and viewModelScopeFactory()
  - Error messages: Include scope info for debugging
  - Documentation: Updated KDoc with correct usage patterns

  Files Changed

  - CoreResolverV2.kt - Stricter resolution logic
  - KoinAnnotations.kt - New @KoinViewModelScopeApi
  - KoinOption.kt - Annotated viewModelScopeFactory()
  - ViewModelScopeArchetypeDSL.kt - Annotated + improved KDoc
  - ViewModelScopeArchetypeTest.kt - Updated to correct pattern

  Impact

  - No impact if viewModelScopeFactory() not used
  - No impact if only using manual scope (KoinScopeComponent)
  - Breaking only for constructor injection with scoped deps declared outside viewModelScope { }

