### PR TITLE
4.2.0-beta3-rc7 - Fix #2337 - Fix CoreResolverV2.kt to handle injected params first

### DIFF
--- a/examples/gradle/versions.gradle
+++ b/examples/gradle/versions.gradle
@@ -2,7 +2,7 @@ ext {
     // Kotlin
     kotlin_version = '2.3.20-Beta1'
     // Koin Versions
-    koin_version = '4.2.0-beta3-rc6'
+    koin_version = '4.2.0-beta3-rc7'
     koin_android_version = koin_version
     koin_compose_version = koin_version
 

--- a/examples/jvm-perfs/build.gradle.kts
+++ b/examples/jvm-perfs/build.gradle.kts
@@ -28,7 +28,6 @@ val koinVersion = extra["koin_version"] as String
 dependencies {
     api("io.insert-koin:koin-core:$koinVersion")
     api("io.insert-koin:koin-core-coroutines:$koinVersion")
-    api("io.insert-koin:koin-fu:$koinVersion")
     implementation("org.openjdk.jmh:jmh-core:$jmhVersion")
     kapt("org.openjdk.jmh:jmh-generator-annprocess:$jmhVersion")
 }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolverV2.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolverV2.kt
@@ -44,9 +44,9 @@ class CoreResolverV2(
     }
 
     private fun <T> resolveFromContextOrNull(scope : Scope, instanceContext: ResolutionContext): T? {
-        return resolveFromRegistry(scope, instanceContext)
-            ?: resolveFromInjectedParameters(instanceContext)
+        return resolveFromInjectedParameters(instanceContext)
             ?: resolveFromStackedParameters(scope,instanceContext)
+            ?: resolveFromRegistry(scope, instanceContext)
             ?: resolveInExtensions(scope,instanceContext)
     }
 

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ParametersInjectionTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ParametersInjectionTest.kt
@@ -376,4 +376,74 @@ class ParametersInjectionTest {
             }
         }
     }
+
+    // Test classes for #2337
+    class SharedViewModel(val id: Int)
+    class ConsumerViewModel(val shared: SharedViewModel)
+
+    /**
+     * Test for issue #2337 - Injected parameters should take precedence over registry resolution
+     * When passing an existing instance via parametersOf(), that instance should be used directly
+     * instead of Koin trying to resolve/recreate it from the registry definition.
+     *
+     * This simulates the common Compose Navigation pattern where a SharedViewModel is passed
+     * to another ViewModel via parametersOf().
+     */
+    @Test
+    fun `injected parameter instance should be used directly - not resolved from registry`() {
+        // Pre-existing SharedViewModel instance (simulates one already created in a parent screen)
+        val existingSharedVM = SharedViewModel(42)
+
+        val app = koinApplication {
+            printLogger(Level.DEBUG)
+            modules(
+                module {
+                    // SharedViewModel has a definition that requires an Int parameter
+                    // If Koin tries to resolve from registry, it will fail without the Int
+                    single { (id: Int) -> SharedViewModel(id) }
+                    // ConsumerViewModel depends on SharedViewModel
+                    factory { ConsumerViewModel(get()) }
+                },
+            )
+        }
+
+        val koin = app.koin
+
+        // Pass existing SharedViewModel instance via parameters
+        // This should use the passed instance directly, NOT try to create a new one from registry
+        val consumer: ConsumerViewModel = koin.get { parametersOf(existingSharedVM) }
+
+        // Verify that the exact same instance was used (not a new one from registry)
+        assertEquals(existingSharedVM, consumer.shared)
+        assertEquals(42, consumer.shared.id)
+    }
+
+    /**
+     * Additional test for #2337 - Ensure parameter instance takes priority over definition
+     * even when definition exists and could technically be resolved
+     */
+    @Test
+    fun `parameter instance takes priority over existing definition`() {
+        val passedInstance = Simple.ComponentA()
+
+        val app = koinApplication {
+            printLogger(Level.DEBUG)
+            modules(
+                module {
+                    // ComponentA has a definition in registry
+                    single { Simple.ComponentA() }
+                    // ComponentB depends on ComponentA
+                    factory { Simple.ComponentB(get()) }
+                },
+            )
+        }
+
+        val koin = app.koin
+
+        // Pass our own ComponentA instance - should use this one, not the one from registry
+        val b: Simple.ComponentB = koin.get { parametersOf(passedInstance) }
+
+        // Verify that our passed instance was used, not the singleton from registry
+        assertEquals(passedInstance, b.a)
+    }
 }

--- a/projects/gradle.properties
+++ b/projects/gradle.properties
@@ -11,7 +11,7 @@ kotlin.incremental.multiplatform=true
 kotlin.code.style=official
 
 #Koin
-koinVersion=4.2.0-beta3-rc6
+koinVersion=4.2.0-beta3-rc7
 
 #Compose
 org.jetbrains.compose.experimental.jscanvas.enabled=true


### PR DESCRIPTION
Fix #2337 - Fix CoreResolverV2.kt to handle injected params first.