### PR TITLE
fix: add volatile and test for concurrency

### DIFF
--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
@@ -77,6 +77,7 @@ class Scope(
             _parameterStack ?: ThreadLocal<ArrayDeque<ParametersHolder>>().also { _parameterStack = it }
         }
 
+    @Volatile
     private var _closed: Boolean = false
     val logger: Logger get() = _koin.logger
 

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ConcurrencyTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ConcurrencyTest.kt
@@ -101,4 +101,62 @@ class ConcurrencyTest {
         assertTrue(result.values.all { it == 1 })
     }
 
+
+    @OptIn(KoinInternalApi::class)
+    @Test
+    fun closed_flag_should_be_visible_across_coroutines_after_close() = runTest {
+        // Verify that scope.closed is visible across threads after close() returns.
+        // Without @Volatile on _closed, a write in close() on one thread may not be
+        // visible to a read on another thread due to CPU cache staleness.
+        //
+        // Strategy: many coroutines on Dispatchers.Default (real threads) each create
+        // a scope, close it, and then verify the closed flag is visible.
+
+        startKoin {
+            modules(module {
+                scope<Counter> {
+                    scoped { CounterService() }
+                }
+            })
+        }
+
+        val iterations = 10_000
+        val staleReads = KoinPlatformTools.safeHashMap<String, Boolean>()
+
+        try {
+            coroutineScope {
+                val jobs = List(iterations) { i ->
+                    launch(kotlinx.coroutines.Dispatchers.Default) {
+                        val koin = KoinPlatform.getKoin()
+                        val counter = Counter()
+                        val scope = koin.createScope<Counter>(counter.getScopeId())
+                        scope.get<CounterService>()
+
+                        // Close on this thread
+                        scope.close()
+
+                        // Immediately check visibility - on a different CPU core,
+                        // without @Volatile this read may see stale false
+                        if (!scope.closed) {
+                            // Double-check after yield to give caches time
+                            kotlinx.coroutines.yield()
+                            if (!scope.closed) {
+                                staleReads[scope.id] = true
+                            }
+                        }
+                    }
+                }
+                jobs.joinAll()
+            }
+        } finally {
+            stopKoin()
+        }
+
+        assertTrue(
+            staleReads.isEmpty(),
+            "Detected ${staleReads.size} stale reads of _closed flag out of $iterations iterations. " +
+                "This indicates _closed is not safely published across threads - it should be @Volatile."
+        )
+    }
+
 }

--- a/projects/core/koin-core/src/jvmTest/kotlin/org/koin/core/ScopeClosedVolatileTest.kt
+++ b/projects/core/koin-core/src/jvmTest/kotlin/org/koin/core/ScopeClosedVolatileTest.kt
@@ -1,0 +1,22 @@
+package org.koin.core
+
+import org.koin.core.scope.Scope
+import java.lang.reflect.Modifier
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ScopeClosedVolatileTest {
+
+    @Test
+    fun `_closed field should be marked volatile for cross-thread visibility`() {
+        // Deterministic check: verify the _closed field has the volatile modifier.
+        // Without @Volatile, writes in close() under synchronized may not be visible
+        // to unsynchronized reads in checkScopeIsOpen() on other threads.
+        val field = Scope::class.java.getDeclaredField("_closed")
+        assertTrue(
+            Modifier.isVolatile(field.modifiers),
+            "Scope._closed field must be @Volatile to guarantee visibility across threads. " +
+                "Without it, a scope closed on Thread A may appear open on Thread B.",
+        )
+    }
+}


### PR DESCRIPTION
After investigating some concurrency issues we've had with version 4.1.1, I realized most of these were fixed with 4.2.0.

But, I believe this one can still cause an issue in rare cases.  **_closed** should be volatile because checkScopeIsOpen() reads _closed outside any lock the JVM is free to let other threads see a stale cached value of false even after close() has fully returned.

It was hard to create a test, but I managed to reproduce with some AI help.

Adding volatile fixes the failing test