### PR TITLE
Fix #2412 - drop displaced factory's cached singleton on override

### DIFF
--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/InstanceRegistry.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/InstanceRegistry.kt
@@ -84,15 +84,20 @@ class InstanceRegistry(val _koin: Koin) {
         factory: InstanceFactory<*>,
         logWarning: Boolean = true,
     ) {
-        _instances[mapping]?.let {
+        _instances[mapping]?.let { displaced ->
             if (!allowOverride) {
                 throwOverrideError(factory, mapping)
-            } else if (logWarning) {
-                _koin.logger.warn("(+) override index '$mapping' -> '${factory.beanDefinition}'")
-                // remove previous eager isntance too
-                val existingFactory = eagerInstances.values.firstOrNull { it.beanDefinition == factory.beanDefinition }
-                if (existingFactory != null) {
-                    eagerInstances.remove(factory.beanDefinition.hashCode())
+            } else {
+                if (logWarning) {
+                    _koin.logger.warn("(+) override index '$mapping' -> '${factory.beanDefinition}'")
+                    // remove previous eager isntance too
+                    val existingFactory = eagerInstances.values.firstOrNull { it.beanDefinition == factory.beanDefinition }
+                    if (existingFactory != null) {
+                        eagerInstances.remove(factory.beanDefinition.hashCode())
+                    }
+                }
+                if (displaced !== factory) {
+                    displaced.dropAll()
                 }
             }
         }

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/DeclareOverrideDropsCachedSingleTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/DeclareOverrideDropsCachedSingleTest.kt
@@ -1,0 +1,59 @@
+package org.koin.core
+
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.mp.KoinPlatform
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+
+/**
+ * Regression test for the override-leak bug: when `declare` overrides a binding,
+ * the original `InstanceFactory` is left orphaned in `Module.mappings` with its
+ * cached singleton intact. After `stopKoin()`, only the declare-installed factory
+ * is reachable from `_instances` and so only that one is dropped; the orphan
+ * survives. The next `startKoin { modules(sameModuleInstance) }` re-registers
+ * the orphan with its stale cache.
+ *
+ * Without the fix in `InstanceRegistry.saveMapping` (drop the displaced factory
+ * on override), this test fails: the second cycle returns the same instance
+ * from cycle 1 with its mutation still present.
+ */
+class DeclareOverrideDropsCachedSingleTest {
+
+    private class Counter {
+        var value: Int = 0
+    }
+
+    @AfterTest
+    fun stop() {
+        runCatching { stopKoin() }
+    }
+
+    @Test
+    fun `declare override drops the displaced factory's cached singleton across stopKoin`() {
+        val sharedModule = module {
+            single { Counter() }
+        }
+
+        // Cycle 1: resolve & mutate the module's singleton, then declare an override.
+        startKoin { modules(sharedModule) }
+        val first = KoinPlatform.getKoin().get<Counter>()
+        first.value = 999
+
+        // declare swaps the registry mapping but leaves the original factory in
+        // sharedModule.mappings holding `first` as its cached value.
+        KoinPlatform.getKoin().declare<Counter>(Counter())
+
+        stopKoin()
+
+        // Cycle 2: reload the same Module instance.
+        startKoin { modules(sharedModule) }
+        val second = KoinPlatform.getKoin().get<Counter>()
+
+        assertNotSame(first, second, "stopKoin must reset the module-owned singleton even after a `declare` override")
+        assertEquals(0, second.value, "fresh singleton should not carry mutated state from the previous Koin lifecycle")
+    }
+}


### PR DESCRIPTION
Fixes #2412.

When `InstanceRegistry.saveMapping` overrides an existing mapping (e.g. via `koin.declare(...)`), the displaced `InstanceFactory` was left with its `value` still cached. Because `Module.mappings` shares factory references with the registry, the orphan survived `stopKoin()` (which only iterates `_instances`) and was re-installed on the next `startKoin { modules(sameModule) }`, leaking the previous lifecycle's singleton into the new one.

This is a long-standing latent bug — present in every released koin version going back to 3.x. It only manifests when the same `Module` instance is loaded across multiple `stopKoin`/`startKoin` cycles after a `declare` override has populated the displaced factory's cache. That combination is rare in production but routine in test setups; in particular it became newly visible in late-2024 / 2025 to users of `kotest-extensions-koin` after kotest 6 turned `Spec.extensions` from a function into a property. See the issue for the full diagnosis, the kotest-6 connection, and a public reproduction repo.

The fix is two lines in `saveMapping`'s override branch: when `_instances[mapping]` is being replaced by a *different* factory, call `dropAll()` on the displaced one before overwriting. The `displaced !== factory` guard preserves the no-op behavior when the same factory is re-registered (e.g., loading an already-loaded module).

## Test

Adds `DeclareOverrideDropsCachedSingleTest` covering the regression: declare a fresh override on top of a module-owned `single`, mutate the singleton, `stopKoin`, then `startKoin` with the same module instance — `get<T>()` must return a fresh singleton.

- Without the patch the test fails on the `assertNotSame(first, second)` and `assertEquals(0, second.value)` assertions.
- With the patch the new test passes, and the full `:core:koin-core:jvmTest` is green (284/284, including all of `DeclareInstanceTest` — no behavior change for documented `declare`/override semantics, only for the latent cache leak).
