### PR TITLE
Fix documentation typos and broken links

### DIFF
--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -47,7 +47,7 @@ See how Koin compares:
 ### Ready to Code?
 
 - **[Setup Guide](/docs/setup/gradle)** - Add Koin to your project
-- **[Tutorials](/docs/tutorials/your-first-app)** - Build your first Koin app
+- **[Tutorials](/docs/quickstart/kotlin)** - Build your first Koin app
 - **[Koin IDE Plugin](https://plugins.jetbrains.com/plugin/26131-koin-dependency-injection-official-)** - Install the official plugin for Android Studio & IntelliJ IDEA — code navigation, live safety checks, dependency graph visualization
 
 ## Koin's Approaches

--- a/docs/intro/what-is-koin.md
+++ b/docs/intro/what-is-koin.md
@@ -223,4 +223,4 @@ Koin is ideal for:
 - **[What is Dependency Injection?](/docs/intro/what-is-dependency-injection)** - Learn DI fundamentals
 - **[Koin Compiler Plugin](/docs/intro/koin-compiler-plugin)** - The recommended approach
 - **[Setup Guide](/docs/setup/gradle)** - Add Koin to your project
-- **[Tutorials](/docs/tutorials/your-first-app)** - Build your first app with Koin
+- **[Tutorials](/docs/quickstart/kotlin)** - Build your first app with Koin

--- a/docs/reference/koin-android/start.md
+++ b/docs/reference/koin-android/start.md
@@ -136,7 +136,7 @@ class MainApplication : Application(), KoinStartup {
 }
 ```
 
-This replaces the `startKoin` function that is usally used in `onCreate`. The `koinConfiguration` function is returning a `KoinConfiguration` instance.
+This replaces the `startKoin` function that is usually used in `onCreate`. The `koinConfiguration` function is returning a `KoinConfiguration` instance.
 
 :::info
 `KoinStartup` integrates with AndroidX App Startup to initialize Koin via ContentProvider before `Application.onCreate()`. This is useful when you need to manage initialization order with other Initializers that depend on Koin being available.

--- a/docs/setup/gradle.md
+++ b/docs/setup/gradle.md
@@ -238,7 +238,7 @@ Last version is currently: [![Maven Central](https://img.shields.io/maven-centra
 | `koin-compose` | Compose (Android & Multiplatform) |
 | `koin-compose-viewmodel` | ViewModel for Compose |
 | `koin-compose-viewmodel-navigation` | Navigation + ViewModel for Compose MP |
-| `koin-androidx-compose` | ⚠️ Superseedeed - use `koin-compose` instead |
+| `koin-androidx-compose` | ⚠️ Superseded - use `koin-compose` instead |
 | `koin-androidx-compose-navigation` | Navigation 2 for Android (not KMP compatible) |
 | `koin-compose-navigation3` | Navigation 3 |
 | `koin-ktor` | Ktor server support |


### PR DESCRIPTION
## Summary

Fixed the following documentation issues:

1. **Typo fix**: Changed 'Superseedeed' to 'Superseded' in `docs/setup/gradle.md`
2. **Typo fix**: Changed 'usally' to 'usually' in `docs/reference/koin-android/start.md`
3. **Broken link fix**: Fixed `/docs/tutorials/your-first-app` link (which pointed to a non-existent tutorials directory) to `/docs/quickstart/kotlin` in `docs/intro/index.md`
4. **Broken link fix**: Fixed the same broken `/docs/tutorials/your-first-app` link to `/docs/quickstart/kotlin` in `docs/intro/what-is-koin.md`

## Changes (4 lines across 4 files)

These are minor but important documentation fixes that improve the user experience for developers new to Koin.

- The typo fixes address grammatical errors that could cause confusion
- The broken link fixes ensure users can navigate to the correct tutorial page