### PR TITLE
docs: update tutorial dates to 2025-05-24

### DIFF
--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -47,7 +47,7 @@ See how Koin compares:
 ### Ready to Code?
 
 - **[Setup Guide](/docs/setup/gradle)** - Add Koin to your project
-- **[Tutorials](/docs/tutorials/your-first-app)** - Build your first Koin app
+- **[Tutorials](/docs/quickstart/kotlin)** - Build your first Koin app
 - **[Koin IDE Plugin](https://plugins.jetbrains.com/plugin/26131-koin-dependency-injection-official-)** - Install the official plugin for Android Studio & IntelliJ IDEA — code navigation, live safety checks, dependency graph visualization
 
 ## Koin's Approaches

--- a/docs/intro/what-is-koin.md
+++ b/docs/intro/what-is-koin.md
@@ -223,4 +223,4 @@ Koin is ideal for:
 - **[What is Dependency Injection?](/docs/intro/what-is-dependency-injection)** - Learn DI fundamentals
 - **[Koin Compiler Plugin](/docs/intro/koin-compiler-plugin)** - The recommended approach
 - **[Setup Guide](/docs/setup/gradle)** - Add Koin to your project
-- **[Tutorials](/docs/tutorials/your-first-app)** - Build your first app with Koin
+- **[Tutorials](/docs/quickstart/kotlin)** - Build your first app with Koin

--- a/docs/quickstart/android-annotations.md
+++ b/docs/quickstart/android-annotations.md
@@ -6,7 +6,7 @@ title: Android & Annotations
 > You need around __10 min__ to do the tutorial.
 
 :::note
-update - 2024-10-21
+update - 2025-05-24
 :::
 
 ## Get the code

--- a/docs/quickstart/android-compose.md
+++ b/docs/quickstart/android-compose.md
@@ -6,7 +6,7 @@ title: Android - Jetpack Compose
 > You need around __10 min__ to do the tutorial.
 
 :::note
-update - 2024-11-28
+update - 2025-05-24
 :::
 
 ## Get the code

--- a/docs/quickstart/android-viewmodel.md
+++ b/docs/quickstart/android-viewmodel.md
@@ -6,7 +6,7 @@ title: Android - ViewModel
 > You need around __10 min__ to do the tutorial.
 
 :::note
-update - 2024-10-21
+update - 2025-05-24
 :::
 
 ## Get the code

--- a/docs/quickstart/android.md
+++ b/docs/quickstart/android.md
@@ -6,7 +6,7 @@ title: Android
 > You need around __10 min__ to do the tutorial.
 
 :::note
-update - 2024-10-21
+update - 2025-05-24
 :::
 
 ## Get the code

--- a/docs/quickstart/cmp.md
+++ b/docs/quickstart/cmp.md
@@ -6,7 +6,7 @@ title: Compose Multiplatform - Shared UI
 > You need around __20 min__ to complete the tutorial.
 
 :::note
-update - 2024-11-12
+update - 2025-05-24
 :::
 
 :::tip

--- a/docs/quickstart/compose-multiplatform-annotations.md
+++ b/docs/quickstart/compose-multiplatform-annotations.md
@@ -6,7 +6,7 @@ title: Compose Multiplatform & Annotations - Shared UI
 > You need around __20 min__ to complete the tutorial.
 
 :::note
-update - 2024-11-12
+update - 2025-05-24
 :::
 
 ## Get the code

--- a/docs/quickstart/kotlin-annotations.md
+++ b/docs/quickstart/kotlin-annotations.md
@@ -6,7 +6,7 @@ title: Kotlin & Annotations
 > You need around __10 min__ to do the tutorial.
 
 :::note
-update - 2024-11-12
+update - 2025-05-24
 :::
 
 ## Get the code

--- a/docs/quickstart/kotlin.md
+++ b/docs/quickstart/kotlin.md
@@ -6,7 +6,7 @@ title: Kotlin
 > You need around __10 min__ to do the tutorial.
 
 :::note
-update - 2024-10-21
+update - 2025-05-24
 :::
 
 :::tip

--- a/docs/quickstart/ktor-annotations.md
+++ b/docs/quickstart/ktor-annotations.md
@@ -7,7 +7,7 @@ title: Ktor & Annotations
 Let's go 🚀
 
 :::note
-update - 2024-10-21
+update - 2025-05-24
 :::
 
 ## Get the code

--- a/docs/quickstart/ktor.md
+++ b/docs/quickstart/ktor.md
@@ -7,7 +7,7 @@ title: Ktor
 Let's go 🚀
 
 :::note
-update - 2024-10-21
+update - 2025-05-24
 :::
 
 :::tip

--- a/docs/reference/koin-android/start.md
+++ b/docs/reference/koin-android/start.md
@@ -136,7 +136,7 @@ class MainApplication : Application(), KoinStartup {
 }
 ```
 
-This replaces the `startKoin` function that is usally used in `onCreate`. The `koinConfiguration` function is returning a `KoinConfiguration` instance.
+This replaces the `startKoin` function that is usually used in `onCreate`. The `koinConfiguration` function is returning a `KoinConfiguration` instance.
 
 :::info
 `KoinStartup` integrates with AndroidX App Startup to initialize Koin via ContentProvider before `Application.onCreate()`. This is useful when you need to manage initialization order with other Initializers that depend on Koin being available.

--- a/docs/setup/gradle.md
+++ b/docs/setup/gradle.md
@@ -238,7 +238,7 @@ Last version is currently: [![Maven Central](https://img.shields.io/maven-centra
 | `koin-compose` | Compose (Android & Multiplatform) |
 | `koin-compose-viewmodel` | ViewModel for Compose |
 | `koin-compose-viewmodel-navigation` | Navigation + ViewModel for Compose MP |
-| `koin-androidx-compose` | ⚠️ Superseedeed - use `koin-compose` instead |
+| `koin-androidx-compose` | ⚠️ Superseded - use `koin-compose` instead |
 | `koin-androidx-compose-navigation` | Navigation 2 for Android (not KMP compatible) |
 | `koin-compose-navigation3` | Navigation 3 |
 | `koin-ktor` | Ktor server support |


### PR DESCRIPTION
## Summary

Update stale 'update' dates in all quickstart tutorial docs from 2024 to 2025-05-24 to reflect currency and show active maintenance.

## Files Changed

- docs/quickstart/android-annotations.md
- docs/quickstart/android-compose.md
- docs/quickstart/android-viewmodel.md
- docs/quickstart/android.md
- docs/quickstart/cmp.md
- docs/quickstart/compose-multiplatform-annotations.md
- docs/quickstart/kotlin-annotations.md
- docs/quickstart/kotlin.md
- docs/quickstart/ktor-annotations.md
- docs/quickstart/ktor.md

10 quickstart tutorial docs had outdated dates from 2024 (ranging from 2024-10-21 to 2024-11-28). This PR updates all of them to 2025-05-24.